### PR TITLE
GH-Issue 176: Fixed redirection to login page and notice in user/main

### DIFF
--- a/src/system/application/libraries/Gravatar.php
+++ b/src/system/application/libraries/Gravatar.php
@@ -20,12 +20,20 @@ class Gravatar {
 	 * @param string $userEmail[optional] User email address
 	 */
 	public function getUserImage($userId,$userEmail=null){
+		if ($userId === false) {
+			return false;
+		}
+		
 		$hash=$this->buildEmailHash($userEmail);
 		$path=$this->_servicePath.'/'.$hash.'?d=mm';
 		
 		if(!$userEmail){
 			$this->CI->load->model('user_model');
-			$userDetail=$this->CI->user_model->getUser($userId);
+			$userDetail = $this->CI->user_model->getUser($userId);
+			if (empty($userDetail)) {
+				return false;
+			}
+			
 			$userEmail=$userDetail[0]->email;
 		}
 		
@@ -41,6 +49,10 @@ class Gravatar {
 	 * @param boolean $return Return as string or echo
 	 */
 	public function displayUserImage($userId,$return=false){
+		if ($userId === false) {
+			return false;
+		}
+
 		if(is_file($this->_cacheDir.'/user'.$userId.'.jpg')){
 			// Check the time on the file....
 			if(filectime($this->_cacheDir.'/user'.$userId.'.jpg')+$this->_imgTimeout<time()){


### PR DESCRIPTION
Dear Team,

The error/notice thrown upon visiting the user/main page (when not logged in) was caused by the displayUserImage method which tried to call the getUserImage method. This method then tried to retrieve a user object and when it failed would output error messages to the browser. This output prevented the headers from redirecting the user to the login page. 

By adding extra checks I was able to prevent the errors / notices and thus was correctly returned to the login page.

Kind regards,

Mike van Riel
