### PR TITLE
GH-Issue 193: store contact e-mail and name upon event submit

### DIFF
--- a/doc/db/patch12.sql
+++ b/doc/db/patch12.sql
@@ -1,0 +1,7 @@
+# adding fields contact_full_name and contact_email
+
+ALTER TABLE `events`
+	ADD `event_contact_name` VARCHAR( 200 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL ,
+	ADD `event_contact_email` VARCHAR( 200 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL;
+
+INSERT INTO patch_history SET patch_number = 12;

--- a/src/system/application/controllers/event.php
+++ b/src/system/application/controllers/event.php
@@ -287,7 +287,9 @@ class Event extends Controller {
 				'private'		=>$this->input->post('event_private'),
 				'event_tz_cont'		=>$this->input->post('event_tz_cont'),
 				'event_tz_place'	=>$this->input->post('event_tz_place'),
-				'event_stub'	=>$this->input->post('event_stub')
+				'event_stub'	=>$this->input->post('event_stub'),
+				'event_contact_name'  => $this->input->post('event_contact_name'),
+				'event_contact_email'	=> $this->input->post('event_contact_email'),
 			);
 			if($this->upload->do_upload('event_icon')){
 				$updata=$this->upload->data();
@@ -334,7 +336,13 @@ class Event extends Controller {
 		$this->load->model('talk_comments_model','tcm');
 		$this->load->model('user_admin_model','uadm');
 		$this->load->model('talks_model');
-		
+
+		// validate user input (id)
+		if (!ctype_digit($id))
+		{
+			show_error('An invalid event id was provided');
+		}
+
 		$events		= $this->event_model->getEventDetail($id);
 		$evt_admins	= $this->event_model->getEventAdmins($id);
 		
@@ -787,7 +795,9 @@ class Event extends Controller {
 				'event_tz_cont'		=>$this->input->post('event_tz_cont'),
 				'event_tz_place'	=>$this->input->post('event_tz_place'),
 				'pending'		=>1,
-				'private'		=>($this->input->post('is_private')=='n') ? null : $this->input->post('is_private')
+				'private'		=>($this->input->post('is_private')=='n') ? null : $this->input->post('is_private'),
+				'event_contact_name'  => $this->input->post('event_contact_name'),
+				'event_contact_email'	=> $this->input->post('event_contact_email'),
 			);
 			
 			// Check to see if our Call for Papers dates are set...


### PR DESCRIPTION
Dear Team,

I have added 2 new database fields to the events table: event_contact_email and event_contact_name.
Whenever a new event is submitted by a visitor / user the contact name and e-mail address which he/she has filled in is now stored in the database.

As discussed with Enygma no changes were made in the add or edit action.

Kind regards,

Mike van Riel
