### PR TITLE
Fix patch sql

### DIFF
--- a/doc/db/patch7.sql
+++ b/doc/db/patch7.sql
@@ -1,4 +1,4 @@
-alter table talk_comments add index idx_talk (talk_id, rating);
+alter table talk_comments drop index idx_talk, add index idx_talk (talk_id, rating);
 alter table talk_cat add index idx_talk_cat (talk_id, cat_id);
 alter table talks add index idx_talk_event (event_id);
 


### PR DESCRIPTION
Fixes patch7.sql to drop idx_talk before trying to add it again.
