### PR TITLE
GH-issue #128: Error handling / error reporting

### DIFF
--- a/README
+++ b/README
@@ -70,6 +70,18 @@ If you'd like some seed data, you can use the seed.sql to load in a few events,
 users and talks. You'll also need to load in the seed_countries.sql file to
 get the complete list of countries for the event details.
 
+Debugging
+#############
+By default the application is in production mode. This primarily means that
+error messages and notices are suppressed.
+
+To allow errors and notices to be shown on the site you have to change the
+environment variable JOINDIN_DEBUG to the value 'on'. It is discouraged to
+do this on production environments as this will allow visitors to see any
+errors produced by the site.
+
+The JOINDIN_DEBUG environment variable is controlled from the accompanying
+.htaccess file.
 
 Tests
 #############

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -2,6 +2,10 @@
     RewriteEngine On
     RewriteBase /
 
+	# Environment variable to enable or disable the display of errors.
+	# It is commented to allow Virtual Hosts to determine this variable.
+    # SetEnv JOINDIN_DEBUG off
+
     #Removes access to the system folder by users.
     #Additionally this will allow you to create a System.php controller,
     #previously this would not have been possible.

--- a/src/index.php
+++ b/src/index.php
@@ -9,7 +9,7 @@
 | For more info visit:  http://www.php.net/error_reporting
 |
 */
-	error_reporting(E_ALL);
+	error_reporting((isset($_SERVER['JOINDIN_DEBUG']) && ($_SERVER['JOINDIN_DEBUG'] == 'on')) ? E_ALL : 0);
 
 /*
 |---------------------------------------------------------------


### PR DESCRIPTION
Dear Team,

I have made a slight adjustment in the index file to check for an environment variable JOINDIN_DEBUG. If it does not exist or is not set to 'on' then the site will assume that it is live and set error_reporting to 0.
The README has also been updated to show this.

Kind regards,

Mike
