### PR TITLE
https for login

### DIFF
--- a/src/system/application/config/config.php.dist
+++ b/src/system/application/config/config.php.dist
@@ -21,7 +21,7 @@ $config['site_name']	= 'Joind.in';
 |	http://example.com/
 |
 */
-$config['base_url']	= ( empty($_SERVER['HTTPS']) ? 'http' : 'https' ) . '://joind.in/';
+$config['base_url']	= 'https://joind.in/';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
By setting the base_url to use https the login always uses a secure connection. A side effect is that all forms will be send securely.
