### PR TITLE
Joindin 57 - date end range not used (or: search returns incorrect items) 

### DIFF
--- a/src/system/application/models/event_model.php
+++ b/src/system/application/models/event_model.php
@@ -489,8 +489,8 @@ SQL
 		if($start>0){ $this->db->where('event_start >=', $start); }
 		if($end>0){ $this->db->where('event_start <=', $end); }
 
-		$this->db->like('event_name',$term);
-		$this->db->or_like('event_desc',$term);
+        $term = '%'.$term.'%';
+        $this->db->where(sprintf('(event_name LIKE %1$s OR event_desc LIKE %1$s)', $this->db->escape($term)));
 		$this->db->limit(10);
 		$this->db->group_by('events.ID');
 

--- a/src/system/application/models/talks_model.php
+++ b/src/system/application/models/talks_model.php
@@ -480,9 +480,9 @@ class Talks_model extends Model {
 		if($start>0){ $this->db->where('date_given >=', $start); }
 		if($end>0){ $this->db->where('date_given <=', $end); }
 		
-		$this->db->like('talk_title',$term);
-		$this->db->or_like('talk_desc',$term);
-		$this->db->or_like('speaker',$term);
+        $term = '%'.$term.'%';
+        $this->db->where(sprintf('(talk_title LIKE %1$s OR talk_desc LIKE %1$s OR speaker LIKE %1$s)', $this->db->escape($term)));
+
 		$this->db->limit(10);
 		$this->db->group_by('talks.ID');
 		$query = $this->db->get();


### PR DESCRIPTION
Looks like the end query is used, but it's an issue with the query builder:

select ... where event_start<=[start] AND event_start>=[end] AND event_title=%term% OR event_desc=%term% 

will result into a incorrect query. The correct query should be:

select ... where event_start<=[start] AND event_start>=[end] AND (event_title=%term% OR event_desc=%term%)

It looks like this is not possible with CI, so i've changed the like/or_like in the search to a generic sql query.
