### PR TITLE
First closing CFP event will be on top

### DIFF
--- a/src/system/application/models/event_model.php
+++ b/src/system/application/models/event_model.php
@@ -470,7 +470,7 @@ SQL
 	{
         $where = 'event_cfp_start <= ' . mktime(0,0,0, date('m'), date('d'), date('Y')) . ' AND '
             . 'event_cfp_end >= ' . mktime(0,0,0, date('m'), date('d'), date('Y'));
-        $order_by = "events.event_cfp_end desc";
+        $order_by = "events.event_cfp_end asc";
 		$result = $this->getEvents($where, $order_by, null);
         return $result;
 	}


### PR DESCRIPTION
Sorry, no issue number since the jira is not functioning. Changed sort ordering for cfp events so the even that closes the earliest will be on top
