### PR TITLE
Don't display end-date when it's the same day as the start

### DIFF
--- a/src/system/application/views/event/_event-row.php
+++ b/src/system/application/views/event/_event-row.php
@@ -6,7 +6,11 @@ $this->load->library('timezone');
 	<?php $this->load->view('event/_event-icon',array('event'=>$event, 'showlink' => true)); ?>
 	<div class="text">
     	<h3><a href="/event/view/<?php echo $event->ID; ?>"><?php echo escape($event->event_name); ?></a></h3>
-		<p class="info"><strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event->event_start, $event->event_tz_cont.'/'.$event->event_tz_place, 'M j, Y'); ?></strong> - <strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event->event_end, $event->event_tz_cont.'/'.$event->event_tz_place, 'M j, Y'); ?></strong> at <strong><?php echo escape($event->event_loc); ?></strong></p>
+		<p class="info"><strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event->event_start, $event->event_tz_cont.'/'.$event->event_tz_place, 'M j, Y'); ?></strong>
+        <?php if ($event->event_start+86399 != $event->event_end) { ?>
+        - <strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event->event_end, $event->event_tz_cont.'/'.$event->event_tz_place, 'M j, Y'); ?></strong> at <strong><?php echo escape($event->event_loc); ?></strong>
+        <?php } ?>
+        </p>
     	<div class="desc">
         <?php echo auto_p(escape(word_limiter($event->event_desc, 20))); ?>
     	</div>

--- a/src/system/application/views/event/calendar.php
+++ b/src/system/application/views/event/calendar.php
@@ -11,7 +11,11 @@ table.calendar td.calendar-day { height: 35px; }
 <?php
 foreach($events as $event){
 	echo '<a style="font-size:14px;font-weight:bold" href="/event/view/'.$event->ID.'">'.$event->event_name.'</a><br/>';
-	echo date('m.d.Y',$event->event_start).' - '.date('m.d.Y',$event->event_end).' <br/>';
+    echo date('m.d.Y',$event->event_start);
+    if ($event->event_start+86399 != $event->event_end) {
+        echo ' - '.date('m.d.Y',$event->event_end);
+    }
+    echo ' <br/>';
 	$split_by_space=explode(' ',$event->event_desc);
 	echo implode(" ",array_slice($split_by_space,0,80)).'...';
 	echo '<br/><br/>';

--- a/src/system/application/views/event/modules/_event_detail.php
+++ b/src/system/application/views/event/modules/_event_detail.php
@@ -22,7 +22,10 @@ $is_cfp_open = ($event_detail->event_cfp_end>=time() && $event_detail->event_cfp
 				<?php endif; ?>
             
             	<p class="info">
-					<strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_start, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong> - <strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_end, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong>
+					<strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_start, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong>
+                    <?php if ($event_detail->event_start+86399 != $event_detail->event_end) { ?>
+                        - <strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_end, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong>
+                    <?php } ?>
             		<br/> 
             		<strong><?php echo escape($event_detail->event_loc); ?></strong>
 					<?php if($event_detail->private==1): ?>

--- a/src/system/application/views/event/modules/_event_detail_summary.php
+++ b/src/system/application/views/event/modules/_event_detail_summary.php
@@ -17,7 +17,10 @@ here's what we need
             	<h1><?php echo escape($event_detail->event_name)?> <?php echo (($event_detail->pending==1) ? '(Pending)':'')?></h1>
             
             	<p class="info">
-					<strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_start, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong> - <strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_end, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong>
+					<strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_start, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong>
+                    <?php if ($event_detail->event_start+86399 != $event_detail->event_end) { ?>
+                        - <strong><?php echo $this->timezone->formattedEventDatetimeFromUnixtime($event_detail->event_end, $event_detail->event_tz_cont.'/'.$event_detail->event_tz_place, 'M j, Y'); ?></strong>
+                    <?php } ?>
             		<br/> 
             		<strong><?php echo escape($event_detail->event_loc); ?></strong>
 					<?php if($event_detail->private==1): ?>

--- a/src/system/application/views/talk/add.php
+++ b/src/system/application/views/talk/add.php
@@ -41,7 +41,9 @@ $priv=($evt_priv===true) ? ', Private Event' : '';
 	<label for="event"></label>
 	<?php
 	echo form_hidden('event_id',$ev->ID);
-	echo '<b><a href="/event/view/'.$ev->ID.'">'.escape($ev->event_name).'</a> ('.date('M d.Y',$ev->event_start).' - '.date('M d.Y',$ev->event_end).$priv.')</b>';
+	echo '<b><a href="/event/view/'.$ev->ID.'">'.escape($ev->event_name).'</a> ('.date('M d.Y',$ev->event_start);
+    if ($ev->event_start+86399 != $ev->event_end) echo '- '.date('m.d.Y',$ev->event_end);
+    echo ')'.$priv.'</b>';
 	?>
 	<div class="clear"></div>
     </div>

--- a/src/system/application/views/user/view.php
+++ b/src/system/application/views/user/view.php
@@ -19,8 +19,9 @@ if($is_admin){
 <?php 
 foreach($pending_evt as $e){
 	$det=$e->detail[0];
-	echo '<b style="font-size:14px">'.$det->event_name.'</b><br/>'.date('m.d.Y',$det->event_start).' - ';
-	echo date('m.d.Y',$det->event_end).'<br/>';
+	echo '<b style="font-size:14px">'.$det->event_name.'</b><br/>'.date('m.d.Y',$det->event_start);
+    if ($det->event_start+86399 != $det->event_end) echo '- '.date('m.d.Y',$det->event_end);
+    echo '<br/>';
 }
 ?>
 <br/>


### PR DESCRIPTION
I think I've got managed to find all views that display (event_start - event_end) dates.
