### PR TITLE
Stripping leading 0's from the days

### DIFF
--- a/src/system/application/helpers/common_helper.php
+++ b/src/system/application/helpers/common_helper.php
@@ -204,7 +204,7 @@ if (! function_exists('form_datepicker'))
                 var vals = dateText.split('-');
                 yr.val(vals[2]);
                 mo.get(0).selectedIndex = (vals[0]-1);
-                da.val(vals[1]);
+                da.val(vals[1].replace(/^0/, ""));
             };
             $('#{$day}_{$month}_{$year}').datepicker({
                 showOn: "button",


### PR DESCRIPTION
Fixing bug http://joindin.jira.com/browse/JOINDIN-90.

Still one (small) issue: since the year-selectbox only displays the current year + 6 more years, we cannot select a year in the past even though it's still possible to pick through the datepicker
