### PR TITLE
event/submit cfp_end_mo_check method sets an error on cfp_end_mo field in

### DIFF
--- a/src/system/application/controllers/event.php
+++ b/src/system/application/controllers/event.php
@@ -1885,7 +1885,7 @@ class Event extends Controller
 
         if ($cfp_end >= $evt_st) {
             $this->validation->set_message(
-                'cfp_start_mo_check',
+                'cfp_end_mo_check',
                 'Invalid Call for Papers end date! CfP must end before '
                 .'event start!'
             );


### PR DESCRIPTION
Issue 102: event/submit cfp_end_mo_check method sets an error on cfp_end_mo field instead of cfp_start_mo.
