### PR TITLE
The default configuration sets the two initial events with the same event

### DIFF
--- a/doc/db/patch26.sql
+++ b/doc/db/patch26.sql
@@ -1,0 +1,1 @@
+alter table events modify event_stub varchar(30) not null, add unique index(event_stub);

--- a/doc/db/seed.sql
+++ b/doc/db/seed.sql
@@ -99,7 +99,7 @@ insert into events (
 	(select unix_timestamp()+86400),
 	'','','Dallas, Tx',
 	'This is a sample event from the seed load script',
-	'seedload',
+	'seedload2',
 	'','seedload_hash',
 	'http://sampledomain.com',
 	'','',0,


### PR DESCRIPTION
The default configuration sets the two initial events with the same event stub. This commit changes the second event in the create script, and adds a new patch script that sets events.events_stub to not null and adds a unique index.
