### PR TITLE
New patchdb script

### DIFF
--- a/src/scripts/patchdb.sh
+++ b/src/scripts/patchdb.sh
@@ -12,10 +12,10 @@
 #   Parsing code adapted from http://www.linux.com/archive/feed/118031
 #
 ###
-TARGET=
-DBNAME=
-DBUSER=
-DBPASS=
+#TARGET=
+#DBNAME=
+#DBUSER=
+#DBPASS=
 while getopts 't:d:u:p:i' OPTION
 do
     case $OPTION in


### PR DESCRIPTION
I have pretty much re-worked the entire script! I found a few lines that were not used, and some variations of commands that bash on MacOS X did not like, so I have changed them to more standard formats.

You can now specify all the parameters as command line options, so you can go from an empty database to a fully working one with something like:-

bash src/scripts/patchdb.sh -t /Volumes/WORK/paul/joind.in -d joindin -u joind_in -p pleasechangeme -i

The script should still run with TARGET and DBNAME set as environment variables.

I have also rewritten some of the error messages, but I wasn't sure if jenkins or something is expecting the "Fail" / "Success" strings.
