### PR TITLE
Added detailed dialog to claim-talk action, to avoid user confusion

### DIFF
--- a/src/inc/js/talk.js
+++ b/src/inc/js/talk.js
@@ -27,7 +27,26 @@ talk = function (){
 			}
 			
 			if($('#claim_btn').attr('name')=='single'){
-				return true;
+				
+				$('#claim-dialog').dialog({
+					autoOpen: false,
+					resizable: false,
+					modal: true,
+					buttons: {
+						"Yes, Proceeed": function() {
+							window.location.href = $('#claim_btn').attr('href');
+						},
+						Cancel: function() {
+							$( this ).dialog( "close" );
+						}
+					}
+				});
+				
+				//Open confirmation dialog
+				$( "#claim-dialog" ).dialog('open');
+				
+				//Respond to dialog not link
+				return false;
 			}
 			
 			var obj={ 

--- a/src/system/application/views/talk/modules/_talk_buttons.php
+++ b/src/system/application/views/talk/modules/_talk_buttons.php
@@ -32,8 +32,16 @@
 		$class 	= 'multi';
 	}
 	?>
-	<a class="btn-small <?php echo $is_claimed ? 'disabled' : '' ?>" href="<?php echo !$is_claimed ? $link : 'javascript:;' ?>" id="claim_btn" name="<?php echo $class; ?>">Claim talk</a>	
+	<a class="btn-small <?php echo $is_claimed ? 'disabled' : '' ?>" href="<?php echo !$is_claimed ? $link : 'javascript:;' ?>" id="claim_btn" name="<?php echo $class; ?>">Claim talk</a>
 </p>
+
+<div id="claim-dialog">
+	<p>By clicking this button you are declaring that you are the speaker responsible for it and a claim request will be sent to the administrator of the event.</p>
+	<p>If the claim is approved you will be able to edit the information for this talk.</p>
+	<p>Are you sure?</p>
+	
+</div>
 <script type="text/javascript">
 $('#claim_select_div').css('display','none');
+$('#claim-dialog').css('display','none');
 </script>


### PR DESCRIPTION
A dialog with details of the effects and purposes of claiming a talk now appears before triggering the actual action, it gives the user the option to advance or bail out.

Let me know if this is cool, or if the english could use some work. I hope this helps reduce the number of random users claiming talks they want to rate.

Please review JS, i was a bit confused by what code is deprecated or not since line 58 aborts the rest of the script and there is another function in line 123 which seems to not be active.
