### PR TITLE
Event tags are not lost when edit/save fails. Also, tags are filtered to 

### DIFF
--- a/src/system/application/models/tags_events_model.php
+++ b/src/system/application/models/tags_events_model.php
@@ -18,6 +18,10 @@ class Tags_events_model extends Model
 	 */
 	public function addTag($eventId,$tagValue)
 	{
+        // Invalid tag value, do not save tag
+        if (empty($tagValue) || !preg_match('/^[a-zA-Z0-9]+$/',trim($tagValue))) {
+            return false;
+        }
 		// normalize
 		$tagValue = trim(strtolower($tagValue));
 		


### PR DESCRIPTION
Event tags are not lost when edit/save fails. Also, tags are filtered to only allow for unique tags. No duplicates are even attempted to be added when a successful save occurs.

I somehow added a blank/empty tag, so I changed the addTag method on tags_events_model to return false if $tagValue is an empty string or invalid tag value.
