### PR TITLE
Fix typo in message that resulted in a broken link / error page

### DIFF
--- a/src/system/application/controllers/event.php
+++ b/src/system/application/controllers/event.php
@@ -1267,7 +1267,7 @@ class Event extends Controller
         if(!$this->user_model->isAuth()){
             $arr['msg'] = sprintf('
                 <b>Note</b>: you must be logged in to submit an event!<br/><br/>
-                If you do not have an account, you can <a href=="/user/register">sign up here</a>.
+                If you do not have an account, you can <a href="/user/register">sign up here</a>.
             ');
         }
 


### PR DESCRIPTION
The one commit is pretty self-explanatory -- this fixes the typo so users who are not logged in get directed to the proper page.

See http://joind.in/event/submit
