### PR TITLE
Add missing bracket on 'Event Related' tab label and lowercase the 'R'

### DIFF
--- a/src/system/application/views/event/modules/_event_tabs.php
+++ b/src/system/application/views/event/modules/_event_tabs.php
@@ -42,7 +42,7 @@ $tabs->addTab($commentsTab);
 if(isset($evt_sessions) && count($evt_sessions)>0):
     $relatedTab = new joindIn_Tab(
         'evt_related',
-        'Event Related '.count($evt_sessions).')',
+        'Event related ('.count($evt_sessions).')',
         $this->load->view('event/modules/_event_tab_evtrelated', array(), true)
     );
     $tabs->addTab($relatedTab);


### PR DESCRIPTION
Add missing bracket on 'Event Related' tab label and lowercase the 'R' to match case of other titles on page!
