### PR TITLE
Removed extra slash that appeared between the domain name and talk

### DIFF
--- a/src/system/application/libraries/Sendemail.php
+++ b/src/system/application/libraries/Sendemail.php
@@ -42,7 +42,7 @@ class SendEmail {
 You recently laid claim to a talk at the \"%s\" event on %s - \"%s\"
 Your claim has been approved. This talk will now be listed under your account.
 
-%s/talk/view/%s
+%stalk/view/%s
 
 Thanks,
 The %s Crew


### PR DESCRIPTION
A very small change, but I noticed it as soon as I signed up and started using joind.in ;)

The link in the email contained an extra slash, I changed it so that ....

http://joindin.local//talk/view/1

is now....

http://joindin.local/talk/view/1
