### PR TITLE
Fix bad link by providing talk id instead of comment id.

### DIFF
--- a/src/inc/js/site.js
+++ b/src/inc/js/site.js
@@ -47,10 +47,11 @@ function deleteComment(cid,rtype){
 	});
 	return false;
 }
-function commentIsSpam(cid,rtype){
+function commentIsSpam(cid,tid,rtype){
 	var obj=new Object();
 	obj.cid		= cid;
 	obj.rtype	= rtype;
+    obj.tid     = tid;
 	apiRequest('comment','isspam',obj, function(obj) {
 		notifications.alert('Thanks for letting us know!'); return false;
 	});

--- a/src/system/application/libraries/wsactions/comment/Isspam.php
+++ b/src/system/application/libraries/wsactions/comment/Isspam.php
@@ -19,9 +19,10 @@ class Isspam extends BaseWsRequest {
         
         $cid	= $this->xml->action->cid;
         $rtype	= $this->xml->action->rtype;
+        $tid    = $this->xml->action->tid;
         
-        $msg='Spam comment on : ' . $this->CI->config->site_url() . $rtype . '/view/' . $cid;
-        
+        $msg='Spam comment on : ' . $this->CI->config->site_url() . $rtype . '/view/' . $tid . "#comment-" . $cid;
+
         $admin_emails=$this->CI->user_model->getSiteAdminEmail();
         foreach($admin_emails as $user){
             mail($user->email,'Suggested spam comment!',$msg,'From: ' . $this->CI->config->item('email_info'));

--- a/src/system/application/views/talk/modules/_talk_comments.php
+++ b/src/system/application/views/talk/modules/_talk_comments.php
@@ -68,7 +68,7 @@ if (empty($comments)) {
             <?php endif; ?>
             <?php if (
                 (isset($claimed[0]->userid) && $claimed[0]->userid != 0 && isset($currentUserId) && $currentUserId == $claimed[0]->userid) || $admin): ?>
-                <a class="btn-small" href="#" onClick="commentIsSpam(<?php echo $v->ID?>,'talk');return false;">Is Spam</a>
+                <a class="btn-small" href="#" onClick="commentIsSpam(<?php echo $v->ID?>,<?php echo $v->talk_id?>,'talk');return false;">Is Spam</a>
             <?php endif; ?>
         </p>
         <?php if (user_is_admin()): ?>


### PR DESCRIPTION
In addition, add a comment hash to the URL so most browsers will automatically
load the page to that comment.
