### PR TITLE
JOINDIN-141: Call for Papers Showing Open AND Closed

### DIFF
--- a/src/system/application/views/event/modules/_event_detail.php
+++ b/src/system/application/views/event/modules/_event_detail.php
@@ -7,7 +7,7 @@ here's what we need
 
 if ($event_detail->event_cfp_start>=time()) {
     $cfp_status = "pending";
-} elseif ($event_detail->event_cfp_start <= time() && time() <= $event_detail->event_cfp_end) {
+} elseif ($event_detail->event_cfp_start <= time() && mktime(0, 0, 0) <= $event_detail->event_cfp_end) {
     $cfp_status = "open";
 } else {
     $cfp_status = "closed";

--- a/src/system/application/views/event/modules/_event_detail_summary.php
+++ b/src/system/application/views/event/modules/_event_detail_summary.php
@@ -103,7 +103,7 @@ here's what we need
             <?php 
             // If there's a Call for Papers open for the event, let them know
             if(!empty($event_detail->event_cfp_start) || !empty($event_detail->event_cfp_end)){ 
-            $cfp_status=($event_detail->event_cfp_end>=time() && $event_detail->event_cfp_start<=time()) ? 'Open!' : 'Closed';
+            $cfp_status=($event_detail->event_cfp_end>=time() && $event_detail->event_cfp_start<=mktime(0,0,0)) ? 'Open!' : 'Closed';
             ?>
             <div class="links">
                 <b>Call for Papers Status: <?php echo $cfp_status; ?> </b> 


### PR DESCRIPTION
Ensures that the rules around whether a CFP is open or closed are consistent. This commit updates the event detail page to just check the current day of the year which is the same rule as used in the event model's getCurrentCfp() method. We also update _event_detail_summary.php to use the same logic.
