### PR TITLE
JOINDIN-137: Event Admins Can't Delete Comments

### DIFF
--- a/src/system/application/views/talk/modules/_talk_comments.php
+++ b/src/system/application/views/talk/modules/_talk_comments.php
@@ -60,7 +60,7 @@ if (empty($comments)) {
             <?php echo auto_p(escape($v->comment)); ?>
         </div>
         <p class="admin">
-            <?php if (user_is_admin() || $v->user_id==$user_id): ?>
+            <?php if ($detail->allow_comments && (user_is_admin() || $v->user_id==$user_id)): ?>
                 <a class="btn-small edit-talk-comment-btn" href="#" id="<?php echo $v->ID; ?>">Edit</a>
             <?php endif; ?>
             <?php if (user_is_admin() || user_is_admin_event($detail->eid)): ?>


### PR DESCRIPTION
Allow event admins to delete a comment and only show the edit button if comments are still allowed.
