### PR TITLE
Let the database return UTF-8

### DIFF
--- a/src/api-v2/models/ApiMapper.php
+++ b/src/api-v2/models/ApiMapper.php
@@ -39,7 +39,7 @@ class ApiMapper {
                     }
                     $entry[$key] = Timezone::formattedEventDatetimeFromUnixtime($row[$value], $tz, 'c');
                 } else {
-                    $entry[$key] = mb_convert_encoding($row[$value], 'UTF-8');
+                    $entry[$key] = $row[$value];
                 }
             }
             $retval[] = $entry;

--- a/src/api-v2/public/index.php
+++ b/src/api-v2/public/index.php
@@ -20,6 +20,11 @@ $ji_db = new PDO('mysql:host=' . $db['default']['hostname'] .
     $db['default']['username'],
     $db['default']['password']);
 
+// Set the correct charset for this connection
+$ji_db->query("SET NAMES 'utf8' COLLATE 'utf8_general_ci'");
+$ji_db->query('SET CHARACTER SET utf8');
+
+
 // collect URL and headers
 $request = new Request();
 

--- a/src/api-v2/views/HtmlView.php
+++ b/src/api-v2/views/HtmlView.php
@@ -48,7 +48,7 @@ class HtmlView extends ApiView
                 $this->printArray($value);
             } else {
                 // value, with hyperlinked hyperlinks
-                $value = htmlentities($value, ENT_COMPAT, 'ISO-8859-1');
+                $value = htmlentities($value, ENT_COMPAT, 'UTF-8');
                 if (strpos($value, 'http://') === 0) {
                     echo "<a href=\"" . $value . "\">" . $value . "</a>";
                 } else {


### PR DESCRIPTION
The database connection was set to the default character set. This normally isn't utf-8. 

With the help of a SET NAMES UTF-8, all data returned by the database is transferred using utf8. The application doesn't have to convert data manually this way (this WILL have some impact using strlen() and such function, but nobody I know really takes care of that).

Another thing I've changed is the string transformation in the view from ISO-8859-1 to UTF8, since we are dealing with UTF8 of course. I could not find any (relevant) other references to 8859.
