### PR TITLE
removing the error_log calls which happen on every request to the API

### DIFF
--- a/src/system/application/libraries/Service.php
+++ b/src/system/application/libraries/Service.php
@@ -92,7 +92,7 @@ class Service {
         ############################
 
     }
-    function parseReqXML($xml) { error_log($xml);
+    function parseReqXML($xml) {
         $ret_xml=null;
         try {
             $ret_xml=simplexml_load_string($xml);
@@ -100,7 +100,7 @@ class Service {
         return $ret_xml;
     }
     // Transform the json into XML and make a SimpleXML object out of it
-    function parseReqJson($json) { error_log($json);
+    function parseReqJson($json) {
         $js=json_decode($json);
         if (!isset($js->request)) { return false; }
         


### PR DESCRIPTION
Tried to check the error_logs on production, only to see them full of debugging, every incoming call to the old API writes the contents of its message to the log.  This patch stops this behaviour
