### PR TITLE
if the full name is empty, display the username (people need some kind o...

### DIFF
--- a/src/system/application/views/talk/modules/_talk_comments.php
+++ b/src/system/application/views/talk/modules/_talk_comments.php
@@ -14,7 +14,8 @@ if (empty($comments)) {
     
     foreach ($comments as $k => $v) {
         if (isset($v->user_id) && $v->user_id != 0) {
-            $uname = '<a href="/user/view/'.$v->user_id.'">'.escape($v->full_name).'</a> ';
+						$displayname = (empty($v->full_name)) ? $v->username : $v->full_name;
+            $uname = '<a href="/user/view/'.$v->user_id.'">'.escape($displayname).'</a> ';
         } else { 
             $uname = '<span class="anonymous">Anonymous</span>'; 
         }


### PR DESCRIPTION
...f ID)

fix for JOINDIN-180 (or well, the twitter username was not the issue, it was an empty display name)
