### PR TITLE
JOINDIN-186 BUGFIX: Preserve referrer upon unauthenticated oauth request

### DIFF
--- a/src/system/application/controllers/user.php
+++ b/src/system/application/controllers/user.php
@@ -724,7 +724,7 @@ class User extends AuthAbstract
     function oauth_allow()
     {
         if (!$this->user_model->isAuth()) {
-            redirect('user/login', 'refresh');
+            redirect('user/login');
         }
 
         $this->load->model('user_admin_model');


### PR DESCRIPTION
When processing an OAUTH request, the user's authentication status is checked. If the user isn't authenticated, joind.in redirects the user to the login form. This redirect is performed using a META refresh (i.e. Refresh: 0;url=xxx in header) that isn't standard or consistent across browsers and ultimately leads to referrer information being lost. (This affects IE, Firefox, at least.)

This leads to an issue where the user is never returned to the OAUTH callback URL.

In _this_ case, I removed the 'refresh' flag so a normal 302 redirect is performed.

Note, however, this issue may be present elsewhere in the codebase. Suggest a review of all redirect calls. (Or perhaps if keeping referral information intact is important, remove the 'refresh' mechanism altogether.)
