### PR TITLE
Remove reference to undefined variables

### DIFF
--- a/src/system/application/views/user/apikey.php
+++ b/src/system/application/views/user/apikey.php
@@ -1,7 +1,7 @@
 <h1>API Access Keys</h1>
 <?php
-$this->load->view('user/_nav_sidebar', array('pending_events'=>$pending_events,
-                                            'event_claims'=>$event_claims));
+$this->load->view('user/_nav_sidebar', array('pending_events'=>array(),
+                                            'event_claims'=>array()));
 ?>
 <?php
 if(isset($grants) && is_array($grants)) {


### PR DESCRIPTION
Doesn't include pending events and whatnot, but does solve the undefined variable notices.
