### PR TITLE
Joindin 166 - Comments are double escaped

### DIFF
--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -748,7 +748,15 @@ class Talk extends Controller
                         $is_claim_approved = true;
                     }
                 }
-                
+
+        if (isset($this->validation->comment)) {
+            // because CI has decided to embed htmlspecialchars in the form helper...
+            $this->validation->translated_comment = htmlspecialchars_decode($this->validation->comment);
+            $this->validation->translated_comment = str_replace(array("&#39;", "&quot;"), array("'", '"'), $this->validation->translated_comment);    
+        } else {
+            $this->validation->translated_comment = '';
+        }
+        
         $arr = array(
             'detail'         => $talk_detail[0],
             'comments'       => (isset($talk_comments['comment']))

--- a/src/system/application/views/talk/modules/_talk_comment_form.php
+++ b/src/system/application/views/talk/modules/_talk_comment_form.php
@@ -1,12 +1,4 @@
 <?php
-function translateComment($comment)
-{
-    // because CI has decided to embed htmlspecialchars in the form helper...
-    $comment = htmlspecialchars_decode($comment);
-    $comment = str_replace(array("&#39;", "&quot;"), array("'", '"'), $comment);
-    return $comment;
-}
-
     $speaker = false;
     foreach ($claimed as $claim) {
         if (isset($claim->userid) && $claim->userid != 0 && user_get_id() == $claim->userid) {
@@ -51,7 +43,7 @@ function translateComment($comment)
     echo form_textarea(array(
         'name'	=> 'comment',
         'id'	=> 'comment',
-        'value'	=> translateComment($this->validation->comment),
+        'value'	=> $this->validation->translated_comment,
         'cols'	=> 40,
         'rows'	=> 10
     ));


### PR DESCRIPTION
adding a "translated_comment" value to "unrender" the escaped value since CI decided putting htmlspecialchars() in the form helper was a good idea
