### PR TITLE
CSRF protection for all forms that use the POST method. Fixes JOINDIN-13

### DIFF
--- a/src/system/application/config/config.php.dist
+++ b/src/system/application/config/config.php.dist
@@ -137,7 +137,7 @@ $config['charset'] = "UTF-8";
 | setting this variable to TRUE (boolean).  See the user guide for details.
 |
 */
-$config['enable_hooks'] = FALSE;
+$config['enable_hooks'] = TRUE;
 
 
 /*

--- a/src/system/application/config/hooks.php
+++ b/src/system/application/config/hooks.php
@@ -10,6 +10,39 @@
 |
 */
 
+//
+// CSRF Protection hooks, don't touch these unless you know what you're
+// doing.
+// See http://net.tutsplus.com/tutorials/php/protect-a-codeigniter-application-against-csrf/
+//
+// THE ORDER OF THESE HOOKS IS EXTREMELY IMPORTANT!!
+//
+
+// THIS HAS TO GO FIRST IN THE post_controller_constructor HOOK LIST.
+$hook['post_controller_constructor'][] = array( // Mind the "[]", this is not the only post_controller_constructor hook
+    'class'    => 'CSRF_Protection',
+    'function' => 'validate_tokens',
+    'filename' => 'csrf.php',
+    'filepath' => 'hooks'
+);
+
+// Generates the token (MUST HAPPEN AFTER THE VALIDATION HAS BEEN MADE, BUT BEFORE THE CONTROLLER
+// IS EXECUTED, OTHERWISE USER HAS NO ACCESS TO A VALID TOKEN FOR CUSTOM FORMS).
+$hook['post_controller_constructor'][] = array( // Mind the "[]", this is not the only post_controller_constructor hook
+    'class'    => 'CSRF_Protection',
+    'function' => 'generate_token',
+    'filename' => 'csrf.php',
+    'filepath' => 'hooks'
+);
+
+// This injects tokens on all forms
+$hook['display_override'] = array(
+    'class'    => 'CSRF_Protection',
+    'function' => 'inject_tokens',
+    'filename' => 'csrf.php',
+    'filepath' => 'hooks'
+);
+
 
 
 /* End of file hooks.php */

--- a/src/system/application/hooks/csrf.php
+++ b/src/system/application/hooks/csrf.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * CSRF Protection Class
+ * From http://net.tutsplus.com/tutorials/php/protect-a-codeigniter-application-against-csrf/
+ * (with tweaks)
+ */
+class CSRF_Protection
+{
+    /**
+     * @var CI instance
+     */
+    private $CI;
+
+    /**
+     * Name used to store token on session - also name of hidden field on form
+     *
+     * @var string
+     */
+    private static $token_name = 'hash';
+
+    /**
+     * Stores the token 
+     * @var string
+     */
+    private static $token;
+
+    // -----------------------------------------------------------------------------------
+
+    public function __construct()
+    {
+        $this->CI =& get_instance();
+    }
+
+    /**
+     * Generates a CSRF token and stores it on session. Only one token per session is generated.
+     * This must be tied to a post-controller hook, and before the hook
+     * that calls the inject_tokens method().
+     *
+     * @return void
+     */
+    public function generate_token()
+    {
+        // Load session library if not loaded
+        $this->CI->load->library('session');
+
+        if ($this->CI->session->userdata(self::$token_name) === FALSE)
+        {
+            // Generate a token and store it on session, since old one appears to have expired.
+            self::$token = md5(uniqid() . microtime() . rand());
+
+            $this->CI->session->set_userdata(self::$token_name, self::$token);
+        }
+        else
+        {
+            // Set it to local variable for easy access
+            self::$token = $this->CI->session->userdata(self::$token_name);
+        }
+    }
+
+    /**
+     * Validates a submitted token when POST request is made.
+     *
+     * @return void
+     */
+    public function validate_tokens()
+    {
+        // Is this a post request?
+        if ($_SERVER['REQUEST_METHOD'] == 'POST')
+        {
+            // Is the token field set and valid?
+            $posted_token = $this->CI->input->post(self::$token_name);
+            if ($posted_token === FALSE || $posted_token != $this->CI->session->userdata(self::$token_name))
+            {
+                // Invalid request, send error 400.
+                show_error('Request was invalid. Tokens did not match.', 400);
+            }
+        }
+        // clear token, so that we get a new one for the next request
+        $this->CI->session->set_userdata(self::$token_name, FALSE);
+    }
+
+    /**
+     * This injects hidden tags on all POST forms with the csrf token.
+     *
+     * @return void
+     */
+    public function inject_tokens()
+    { 
+        $output = $this->CI->output->get_output();
+
+        // Inject into any forms that use POST
+        $output = preg_replace('/(<(form|FORM)[^>]*(method|METHOD)="(post|POST)"[^>]*>)/',
+                               '$0<input type="hidden" name="' . self::$token_name . '" value="' . self::$token . '">',
+                               $output);
+
+        $this->CI->output->_display($output);
+    }
+
+}


### PR DESCRIPTION
It's time to fix this one!  It appears to work with my testing, but I'd appreciate it if @magicmonkey could have a look over it too.
