### PR TITLE
Joindin 14

### DIFF
--- a/src/inc/js/site.js
+++ b/src/inc/js/site.js
@@ -125,9 +125,29 @@ function removeRole(aid){
 	obj.aid=aid;
 	obj.type='remove';
 	apiRequest('user','role',obj, function(obj) {
-		$('#resource_row_'+aid).css('display','none');
+		$('#resource_row_'+obj.aid).css('display','none');
 	});
 }
+
+function unlinkSpeaker(talk_id, speaker_id, css_row_id){
+	var obj=new Object();
+	obj.talk_id=talk_id;
+	obj.speaker_id=speaker_id;
+	obj.css_row_id=css_row_id;
+	apiRequest('user', 'unlink', obj, function(obj) {
+		$('#resource_row_'+obj.css_row_id).hide();
+	});
+}
+
+function removeTalkClaim(claim_id, css_row_id){
+	var obj=new Object();
+	obj.claim_id=claim_id;
+	obj.css_row_id=css_row_id;
+	apiRequest('user', 'removeTalkClaim', obj, function(obj) {
+		$('#resource_row_'+obj.css_row_id).hide();
+	});
+}
+
 function populateEvents(fname){
 	var obj=new Object();
 	apiRequest('event','getlist',obj, function(obj) {

--- a/src/system/application/controllers/api.php
+++ b/src/system/application/controllers/api.php
@@ -165,7 +165,11 @@ class Api extends Controller
             } else {
                 $out = 'out_json';
             }
-            $this->load->view('api/' . $out, $ret['out']['data']);
+            $params = $ret['out'];
+            if (isset($ret['out']['data'])) {
+                $params = $ret['out']['data'];
+            }
+            $this->load->view('api/' . $out, $params);
         } else {
             $arr = array('items' => array(
                 'msg' => 'Unknown Error'

--- a/src/system/application/controllers/user.php
+++ b/src/system/application/controllers/user.php
@@ -369,6 +369,7 @@ class User extends AuthAbstract
     function view($uid)
     {
         $this->load->model('talks_model');
+        $this->load->model('pending_talk_claims_model');
         $this->load->model('user_attend_model', 'uam');
         $this->load->model('user_admin_model', 'uadmin');
         $this->load->model('speaker_profile_model', 'spm');
@@ -405,8 +406,10 @@ class User extends AuthAbstract
             'is_admin'      => $this->user_model->isSiteAdmin(),
             'is_attending'  => $this->uam->getUserAttending($uid),
             'my_attend'     => $this->uam->getUserAttending($curr_user),
-            'uadmin'        => $this->uadmin->getUserTypes(
-                $uid, array('talk', 'event')
+            'uadmin'        => array(
+                'events'        => $this->uadmin->getUserTypes($uid, array('event')),
+                'talks'         => $this->talks_model->getSpeakerTalks($uid, true),
+                'pending_talks' => $this->pending_talk_claims_model->getTalkClaimsForUser($uid),
             ),
             'reqkey'        => $reqkey,
             'seckey'        => buildSecFile($reqkey),

--- a/src/system/application/libraries/wsactions/user/RemoveTalkClaim.php
+++ b/src/system/application/libraries/wsactions/user/RemoveTalkClaim.php
@@ -1,0 +1,51 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+// Remove a user's claim on a talk
+
+class RemoveTalkClaim extends BaseWsRequest {
+
+    var $CI		= null;
+    var $xml	= null;
+
+    public function RemoveTalkClaim($xml) {
+        $this->CI=&get_instance(); //print_r($this->CI);
+        $this->xml=$xml;
+    }
+
+    /**
+    * Only site admins can use this functionality
+    */
+    public function checkSecurity($xml) {
+
+        $this->CI->load->model('user_model');
+
+        // Check for a valid login
+        //if ($this->isValidLogin($xml) || $this->CI->user_model->isAuth()) {
+        if ($this->CI->user_model->isAuth()) {
+            // Now check to see if they're a site admin
+            $user=$this->CI->session->userdata('username');
+            if (!$this->CI->user_model->isSiteAdmin($user)) {
+                return false;
+            } else { return true; }
+
+        } else { return false; }
+    }
+
+    //-----------------------
+    public function run() {
+
+        $this->CI->load->model('pending_talk_claims_model');
+
+        $result = array();
+        $claim_id = (int)$this->xml->action->claim_id;
+        $css_row_id = (string)$this->xml->action->css_row_id;
+        $result['claim_id'] = $claim_id;
+        $result['css_row_id'] = $css_row_id;
+
+        $this->CI->pending_talk_claims_model->deleteClaim($claim_id);
+
+        $result['msg'] = 'Success';
+        return array('output'=>'json','items'=>$result);
+    }
+
+}

--- a/src/system/application/libraries/wsactions/user/Role.php
+++ b/src/system/application/libraries/wsactions/user/Role.php
@@ -19,7 +19,7 @@ class Role extends BaseWsRequest {
         //if ($this->isValidLogin($xml) || $this->CI->user_model->isAuth()) {
         if ($this->CI->user_model->isAuth()) {
             // Now check to see if they're a site admin
-            $user=$this->session->userdata('username');
+            $user=$this->CI->session->userdata('username');
             if (!$this->CI->user_model->isSiteAdmin($user)) {
                 return false;
             } else { return true; }
@@ -31,20 +31,27 @@ class Role extends BaseWsRequest {
         $this->CI->load->model('user_admin_model','uam');
         $type=$this->xml->action->type;
         
+        $result = array();
         if ($type=='remove') {
             $aid=$this->xml->action->aid;
+            $result['aid'] = (int)$aid;
             $this->CI->uam->removePerm($aid);
         } elseif ($type=='addevent') {
             $uid=$this->xml->action->uid;
             $rid=$this->xml->action->rid;
+            $result['uid'] = (int)$uid;
+            $result['rid'] = (int)$rid;
             $this->CI->uam->addPerm($uid, $rid,'event');
         } elseif ($type=='addtalk') {
             $uid=$this->xml->action->uid;
             $rid=$this->xml->action->rid;
+            $result['uid'] = (int)$uid;
+            $result['rid'] = (int)$rid;
             $this->CI->uam->addPerm($uid, $rid,'talk');
         }
-        
-        return array('output'=>'json','items'=>array('msg'=>'Success'));
+
+        $result['msg'] = 'Success';
+        return array('output'=>'json','items'=>$result);
     }
     
 }

--- a/src/system/application/libraries/wsactions/user/Unlink.php
+++ b/src/system/application/libraries/wsactions/user/Unlink.php
@@ -1,0 +1,53 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+// Unlink a user from a talk
+
+class Unlink extends BaseWsRequest {
+
+    var $CI		= null;
+    var $xml	= null;
+
+    public function Unlink($xml) {
+        $this->CI=&get_instance(); //print_r($this->CI);
+        $this->xml=$xml;
+    }
+
+    /**
+    * Only site admins can use this functionality
+    */
+    public function checkSecurity($xml) {
+
+        $this->CI->load->model('user_model');
+
+        // Check for a valid login
+        //if ($this->isValidLogin($xml) || $this->CI->user_model->isAuth()) {
+        if ($this->CI->user_model->isAuth()) {
+            // Now check to see if they're a site admin
+            $user=$this->CI->session->userdata('username');
+            if (!$this->CI->user_model->isSiteAdmin($user)) {
+                return false;
+            } else { return true; }
+
+        } else { return false; }
+    }
+
+    //-----------------------
+    public function run() {
+
+        $this->CI->load->model('talk_speaker_model');
+
+        $result = array();
+        $talk_id = (int)$this->xml->action->talk_id;
+        $speaker_id = (int)$this->xml->action->speaker_id;
+        $css_row_id = (string)$this->xml->action->css_row_id;
+        $result['talk_id'] = $talk_id;
+        $result['speaker_id'] = $speaker_id;
+        $result['css_row_id'] = $css_row_id;
+
+        $this->CI->talk_speaker_model->unlinkSpeaker($talk_id, $speaker_id);
+
+        $result['msg'] = 'Success';
+        return array('output'=>'json','items'=>$result);
+    }
+
+}

--- a/src/system/application/models/pending_talk_claims_model.php
+++ b/src/system/application/models/pending_talk_claims_model.php
@@ -96,6 +96,25 @@ class Pending_talk_claims_model extends Model
         
         return $results;
     }
+
+    /**
+     * Given the user's id, find all their claims
+     *
+     * @param integer $eventId Event ID
+     * @return array $result Pending claims found
+     */
+    public function getTalkClaimsForUser($userId)
+    {
+        $results = $this->db->select('pending_talk_claims.*, talks.talk_title, talks.event_id, events.event_name, events.event_start, events.event_end')
+            ->from('pending_talk_claims')
+            ->join('talks','pending_talk_claims.talk_id = talks.id')
+            ->join('events','talks.event_id = events.ID')
+            ->where_in('pending_talk_claims.speaker_id', $userId)
+            ->order_by('talks.date_given desc')
+            ->get()->result();
+
+        return $results;
+    }
     
 }
 

--- a/src/system/application/models/talks_model.php
+++ b/src/system/application/models/talks_model.php
@@ -346,20 +346,30 @@ class Talks_model extends Model {
     }
     
     /**
-     * Get successfully claimed talks by speaker
+     * Get successfully claimed talks by speaker. Optionally collect the name
+     * and date of each talk's event.
      *
      * @param integer $speakerId User ID
+     * @param boolean $includeEventInfo
      * @return array 
      */
-    public function getSpeakerTalks($speakerId)
+    public function getSpeakerTalks($speakerId, $includeEventInfo=false)
     {
         $talks = array();
         
-        $this->db->select('*');
-        $this->db->from('talk_speaker');
-        $this->db->join('talks','talks.id=talk_speaker.talk_id');
+        if ($includeEventInfo) {
+            $this->db->select('talk_speaker.*, talks.*, events.event_name, events.event_start, events.event_end');
+            $this->db->from('talk_speaker');
+            $this->db->join('talks','talks.id=talk_speaker.talk_id');
+            $this->db->join('events','talks.event_id = events.ID');
+        } else {
+            $this->db->select('*');
+            $this->db->join('talks','talks.id=talk_speaker.talk_id');
+            $this->db->from('talk_speaker');
+        }
         $this->db->where('speaker_id', $speakerId);
         $this->db->order_by('talks.date_given desc');
+
         
         $query 	= $this->db->get();
         $talks 	= $query->result();

--- a/src/system/application/views/user/view.php
+++ b/src/system/application/views/user/view.php
@@ -202,29 +202,81 @@ foreach ($talks as $k=>$v) {
     <td colspan="2">
         <div class="box">
             <h2>Admin</h2>
+
+            <?php if (!empty($uadmin['events'])) : ?>
+            <p>Events for which they are an admin</p>
             <table cellpadding="3" cellspacing="0" border="0">
             <?php
-            //echo '<pre>'; print_r($uadmin); echo '</pre>';
-            foreach ($uadmin as $k=>$v) {
+            foreach ($uadmin['events'] as $k=>$v) {
                 if (!isset($v->detail[0])) { continue; }
-                if ($v->rtype=='talk') {
-                    $title=$v->detail[0]->talk_title;
-                    $url='/talk/view/'.$v->detail[0]->ID;
-                } else { 
-                    $title=$v->detail[0]->event_name;
-                    $url='/event/view/'.$v->detail[0]->ID;
-                }
+                $title=$v->detail[0]->event_name;
+                $url='/event/view/'.$v->detail[0]->ID;
                 $pend=($v->rcode=='pending') ? ' (pending)':'';
                 echo sprintf('
                     <tr id="resource_row_%s">
-                        <td style="padding:3px">%s</td>
                         <td style="padding:3px"><a href="%s">%s %s</a></td>
-                        <td style="padding:3px"><a href="#" onClick="removeRole(%s);return false;">X</a></td>
+                        <td style="padding:3px">[<a href="#" onClick="removeRole(%s);return false;" title="Remove this user from this event">X</a>]</td>
                     </tr>
-                ', $v->rid, $v->rtype, $url, $title, $pend, $v->admin_id);
+                ', $v->admin_id, $url, $title, $pend, $v->admin_id);
             }
             ?>
             </table>
+            <?php endif; ?>
+
+            <?php if (!empty($uadmin['pending_talks'])) : ?>
+            <p>Pending talk claims</p>
+            <table cellpadding="3" cellspacing="0" border="0">
+            <?php
+            $count = 0;
+            foreach ($uadmin['pending_talks'] as $k=>$v) {
+                $count++;
+                $row_id = 'p'. $count;
+                $url = '/talk/view/'.$v->talk_id;
+                $title = $v->talk_title;
+                $event_url = '/event/view/'.$v->event_id;
+                $event_name = $v->event_name;
+                $event_date = date('M d, Y', $v->event_start);
+                echo sprintf('
+                    <tr id="resource_row_%s">
+                        <td style="padding:3px">
+                            <a href="%s">%s</a>
+                            at <a href="%s">%s</a> %s
+                        </td>
+                        <td style="padding:3px">[<a href="javascript:" onClick="removeTalkClaim(%s, \'%s\');return false;" title="Remove this speaker\'s claim">X</a>]</td>
+                    </tr>
+                ', $row_id, $url, $title, $event_url, $event_name, $event_date, $v->ID, $row_id);
+            }
+            ?>
+            </table>
+            <?php endif; ?>
+
+            <?php if (!empty($uadmin['talks'])) : ?>
+            <p>Claimed talks</p>
+            <table cellpadding="3" cellspacing="0" border="0">
+            <?php
+            $count = 0;
+            foreach ($uadmin['talks'] as $k=>$v) {
+                $count++;
+                $row_id = 't'. $count;
+                $title=$v->talk_title;
+                $url='/talk/view/'.$v->ID;
+                $event_url = '/event/view/'.$v->event_id;
+                $event_name = $v->event_name;
+                $event_date = date('M d, Y', $v->event_start);
+                echo sprintf('
+                    <tr id="resource_row_%s">
+                        <td style="padding:3px">
+                            <a href="%s">%s</a>
+                            at <a href="%s">%s</a> %s
+                        </td>
+                        <td style="padding:3px">[<a href="javascript:" onClick="unlinkSpeaker(%s, %s, \'%s\');return false;" title="Unlink this speaker">X</a>]</td>
+                    </tr>
+                ', $row_id, $url, $title, $event_url, $event_name, $event_date, $v->ID, $v->speaker_id, $row_id);
+            }
+
+            ?>
+            </table>
+            <?php endif; ?>
         </div>
     </td>
 </tr>


### PR DESCRIPTION
As per [JOINDIN-14](https://joindin.jira.com/browse/JOINDIN-14): 

Rework the admin section of user/view so that it works.
1. Remove admin dropdowns from user/view page.
2. We now display three separate tables:
   - Events for which this user is an admin
   - Pending talk claims
   - Claimed talks
   
   For each event or talk, an administrator can choose to remove the user's association by clicking the [X] which uses the JavaScript API controller to perform the action and then hide the table row from display.
