### PR TITLE
Updated dbgen script to create empty event_stub's instead of duplicates

### DIFF
--- a/doc/dbgen/generator.class.php
+++ b/doc/dbgen/generator.class.php
@@ -17,7 +17,7 @@ class Generator {
      */
     public function __construct(Generator_Data_Interface $data) {
         $this->_data = $data;
-		$this->_existing_stubs = array();
+        $this->_existing_stubs = array();
     }
 
     /**


### PR DESCRIPTION
We decided that empty stubs are more "real" than randomly generated data.
