### PR TITLE
Comment edit bug fix

### DIFF
--- a/src/system/application/hooks/csrf.php
+++ b/src/system/application/hooks/csrf.php
@@ -71,7 +71,6 @@ class CSRF_Protection
             // is this an API request?
             if ( strpos($_SERVER['PATH_INFO'], '/api') === 0) {
                     // API call
-                    $this->CI->session->set_userdata(self::$token_name, FALSE);
                     return;
             }
 


### PR DESCRIPTION
Don't clear the user token on API requests, which seems to break comment editing.  Not sure if this change would have any undesirable effects - if so, perhaps there's a better way of fixing it?
