### PR TITLE
Rework the CSRF checks to use a stack of tokens

### DIFF
--- a/src/system/application/hooks/csrf.php
+++ b/src/system/application/hooks/csrf.php
@@ -45,6 +45,9 @@ class CSRF_Protection
 
         // Extract the list of tokens we currently know about
         self::$tokens = $this->CI->session->userdata(self::$token_name);
+        if (!is_array(self::$tokens)) {
+            self::$tokens = array();
+        }
 
         // We only want to keep the most recent tokens
         if (count(self::$tokens) > 5) {


### PR DESCRIPTION
This PR changes the single CSRF token to be a stack of tokens so that a user can have multiple tabs open and submit a form on each tab. And, of course, using a form after using the back button also works!
