### PR TITLE
Remind event submitters that the description needs to be in English

### DIFF
--- a/src/system/application/views/event/submit.php
+++ b/src/system/application/views/event/submit.php
@@ -330,6 +330,7 @@
 
     <div class="row">
         <label for="event_desc">Event Description *</label>
+        <div>(In <em>English</em>, with optional alternative translation)</div>
         <?php
         echo form_textarea(array(
             'name'	=> 'event_desc',


### PR DESCRIPTION
The note at the top of the form is a long way up, and the user may have forgotten in the excitement of filling in the form!

This PR came about a result of reading an IRC discussion between JayTaph and rdohms about PHPSC Conference 2012.
