### PR TITLE
Fix double escape in event comments (JOINDIN-166): moved previous fix wh...

### DIFF
--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -750,14 +750,6 @@ class Talk extends Controller
                     }
                 }
 
-        if (isset($this->validation->comment)) {
-            // because CI has decided to embed htmlspecialchars in the form helper...
-            $this->validation->translated_comment = htmlspecialchars_decode($this->validation->comment);
-            $this->validation->translated_comment = str_replace(array("&#39;", "&quot;"), array("'", '"'), $this->validation->translated_comment);    
-        } else {
-            $this->validation->translated_comment = '';
-        }
-        
         $arr = array(
             'detail'         => $talk_detail[0],
             'comments'       => (isset($talk_comments['comment']))

--- a/src/system/application/helpers/common_helper.php
+++ b/src/system/application/helpers/common_helper.php
@@ -219,4 +219,15 @@ JSCRIPT;
         return $javascript;
     }
 }
+
+/**
+ * Remove htmlspecialchars from a string, used for comments
+ * Because CI has decided to embed htmlspecialchars in the form helper...
+ */
+function translate_htmlspecialchars($comment)
+{
+    $comment = htmlspecialchars_decode($comment);
+    $comment = str_replace(array("&#39;", "&quot;"), array("'", '"'), $comment);
+    return $comment;
+}
 // --------------------------------------------------------------------

--- a/src/system/application/views/event/modules/_event_tab_comments.php
+++ b/src/system/application/views/event/modules/_event_tab_comments.php
@@ -75,7 +75,7 @@ if (time()<$adv_mo): ?>
         $arr = array(
                 'name'=>'event_comment',
                 'id'=>'event_comment',
-                'value'=>$this->validation->event_comment,
+                'value'=>translate_htmlspecialchars($this->validation->event_comment),
                 'cols'=>40,
                 'rows'=>10
         );

--- a/src/system/application/views/talk/modules/_talk_comment_form.php
+++ b/src/system/application/views/talk/modules/_talk_comment_form.php
@@ -43,7 +43,7 @@
     echo form_textarea(array(
         'name'	=> 'comment',
         'id'	=> 'comment',
-        'value'	=> $this->validation->translated_comment,
+        'value'	=> translate_htmlspecialchars($this->validation->comment),
         'cols'	=> 40,
         'rows'	=> 10
     ));


### PR DESCRIPTION
...ich fixed talk comments into common helper, and used that
