### PR TITLE
making site.js load synchronously so it can be used by inline scripts 

### DIFF
--- a/src/system/application/views/template2.php
+++ b/src/system/application/views/template2.php
@@ -20,7 +20,7 @@ $title[] = $this->config->item('site_name');
     <script type="text/javascript" src="/inc/js/jquery.js"></script>
     <script type="text/javascript" src="/inc/js/jquery.pause.js"></script>
     <script type="text/javascript" src="/inc/js/jquery-ui.js"></script>
-    <script type="text/javascript" src="/inc/js/site.js" async></script>
+    <script type="text/javascript" src="/inc/js/site.js"></script>
     <script type="text/javascript" src="/inc/js/notifications.js" async></script>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <?php


### PR DESCRIPTION
This fixes the intermittent bug where we sometimes see radio buttons instead of rating prettiness when commenting on a particular talk.  The asynchronous loading of site.js was causing some inline js to run first and instantly fail.
