### PR TITLE
Updates to codesniffer to add a few more sniffs

### DIFF
--- a/doc/codesniffer/JoindIn/ruleset.xml
+++ b/doc/codesniffer/JoindIn/ruleset.xml
@@ -9,6 +9,20 @@
  <rule ref="PEAR">
    <exclude name="PEAR.Commenting.FileComment"/>
    <exclude name="PEAR.Commenting.ClassComment"/>
+   <exclude name="PEAR.NamingConventions.ValidFunctionName.NotCamelCaps"/>
  </rule> 
-
+ <!-- Omitting the closing php tag can prevent errors where including a file
+      causes output to happen due to whitespace after the closing tag
+   -->
+ <rule ref="Zend.Files.ClosingTag"/>
+ <!-- Aligning the = sign for groups of assignments has been brought up
+      in code reviews, but it wasn't an official coding standard. Now it
+      is
+ -->
+ <rule ref="Generic.Formatting.MultipleStatementAlignment">
+  <properties>
+   <property name="ignoreMultiLine" value="true"/>
+  </properties>
+ </rule>
+ <rule ref="Generic.Files.LineLength" />
 </ruleset>


### PR DESCRIPTION
I added a few sniffs that I think are useful additions to the PEAR standard.

First, disallowing the closing PHP tag because it prevents errors that happen when files are included that have whitespace after the closing PHP tag.

Next is the multi statement alignment since it has come up in some reviews so we may as well make it sniffable. The ignore multi-line is because the sniff can interfere with itself in certain situations where both ways will cause a sniff error.

The last one is the line length. PEAR includes this, but at least for me it was not actually working until I added this. I can remove it after the cleanup is done.
