### PR TITLE
Updated build.xml to ignore views in codesniffer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -49,8 +49,10 @@
  </target>
 
  <target name="phpcs" description="Generate checkstyle.xml using PHP_CodeSniffer">
-  <phpcodesniffer standard="doc/codesniffer/JoindIn/" >
-   <fileset dir="${source}" />
+     <phpcodesniffer standard="doc/codesniffer/JoindIn/" verbosity="1">
+   <fileset dir="${source}">
+       <exclude name="views/**"/>
+   </fileset>
    <formatter type="checkstyle" outfile="${basedir}/build/logs/checkstyle.xml" />
   </phpcodesniffer>
  </target>


### PR DESCRIPTION
The views do all sorts of things that make conforming to code standards and making readable code and well-formatted HTML next to impossible. I don't see any reason to report codesniff violations or try to fix them in the views files so I added a phpcs directive to ignore them. 

It should reduce the number of codesniff violations by about 1746.
