### PR TITLE
Codesniff cleanup for Cache file

### DIFF
--- a/src/system/application/libraries/Cache.php
+++ b/src/system/application/libraries/Cache.php
@@ -1,66 +1,129 @@
 <?php
-if ( ! defined('BASEPATH')) exit('No direct script access allowed');
-
-/* 
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * Caching class. It doesn't appear to be used and is only partially 
+ * implemented. Can we delete it?
+ *
+ * PHP version 5
+ *
+ * @category  Joind.in
+ * @package   Configuration
+ * @copyright 2009 - 2012 Joind.in
+ * @license   http://github.com/joindin/joind.in/blob/master/doc/LICENSE JoindIn
  */
 
-class Cache {
+if (!defined('BASEPATH')) {
+    exit('No direct script access allowed');
+}
 
-    private $_CI	= null;
-    private $_type	= 'file';
-    private $_cpath	= '/tmp';
+/**
+ * Caching class. Seemingly unused.
+ *
+ * @category  Joind.in
+ * @package   Configuration
+ * @copyright 2009 - 2012 Joind.in
+ * @license   http://github.com/joindin/joind.in/blob/master/doc/LICENSE JoindIn
+ */
+class Cache
+{
+
+    private $_CI    = null;
+    private $_type  = 'file';
+    private $_cpath = '/tmp';
+
     /**
      * Our default timeout is an hour...
+     *
+     * @var int
      */
-    private $_timeout	= 3600;
+    private $_timeout = 3600;
 
-    //-------------------
-    public function setCachePath($path) {
-    
+    /**
+     * Does nothing
+     *
+     * @param mixed $path Not used
+     *
+     * @return null
+     */
+    public function setCachePath($path) 
+    {
+
     }
-    public function setCacheTime($sec) {
-    
+
+    /**
+     * Does nothing
+     *
+     * @param mixed $sec Does nothing
+     *
+     * @return null
+     */
+    public function setCacheTime($sec) 
+    {
+
     }
-    public function getData($name) {
-    $file	= $this->_cpath.'/'.$name.'.cache';
-    if (is_file($file)) {
-        $data=unserialize(file_get_contents($file));
-        return $data;
-    } else { return false; }
+
+    /**
+     * Retrieve data from the cache file
+     *
+     * @param string $name Name of cache file
+     *
+     * @return mixed
+     */
+    public function getData($name) 
+    {
+        $file = $this->_cpath . '/' . $name . '.cache';
+
+        if (is_file($file)) {
+            $data = unserialize(file_get_contents($file));
+            return $data;
+        } else { 
+            return false; 
+        }
     }
-    //-------------------
-    
+
     /**
      * Pass in the data to be cached, it'll figure out the
      * right method to use
+     *
+     * @param string $name Cache key
+     * @param mixed  $data Data to store
+     *
+     * @return null
      */
-    public function cacheData($name, $data) {
-    //$this->_CI =& get_instance();
-    $func='ctype_'.$this->_type;
-    if (method_exists($this, $func)) {
-        $this->$func($name, $data);
-    } else {
-        throw new Exception('Invalid cace type!');
+    public function cacheData($name, $data) 
+    {
+        $func = 'ctype_'.$this->_type;
+        if (method_exists($this, $func)) {
+            $this->$func($name, $data);
+        } else {
+            throw new Exception('Invalid cache type!');
+        }
     }
-    }
-    //-------------------
+
     /**
      * Caching to a file, assume we're always overwriting
+     *
+     * @param string $name Name of cache key
+     * @param mixed  $data Data to cache
+     *
+     * @return null
      */
-    private function ctype_file($name, $data) {
-    $file	= $this->_cpath.'/'.$name.'.cache';
-    $sdata	= serialize($data);
-    file_put_contents($file, $sdata);
+    private function ctype_file($name, $data) 
+    {
+        $file  = $this->_cpath . '/' . $name . '.cache';
+        $sdata = serialize($data);
+        file_put_contents($file, $sdata);
     }
 
     /**
-     * Caching to a database
+     * Does nothing
+     *
+     * @param mixed $data Does nothing
+     *
+     * @return null
      */
-    private function ctype_db($data) {
-    
-    }
+    private function ctype_db($data)
+    {
 
+    }
 }
 


### PR DESCRIPTION
As far as I can tell this file is only partially implemented and it is not used anywhere. I'd recommend deleting it as it just adds to noise in the project unless there's some reason to keep it around. If it is being used, please let me know where since grep told me it's nowhere in the src/system/application structure.

In any case, this patch makes it conform to codesniff standards.
