### PR TITLE
If username is provided but blank, return empty comment structure.

### DIFF
--- a/src/system/application/libraries/wsactions/user/Getcomments.php
+++ b/src/system/application/libraries/wsactions/user/Getcomments.php
@@ -69,6 +69,18 @@ class Getcomments extends BaseWsRequest
         $this->CI->load->model('talk_comments_model');
         $this->CI->load->model('event_comments_model');
         
+        // JOINDIN-139 - Empty username will result in an empty
+        // comment structure returned instead of an error.
+        if ($this->xml->action->username == '') {
+            return array(
+                'type' => 'json',
+                'data' => array(
+                    'items' => array(),
+                    'user'  => $this->xml->action->username
+                )
+            );
+        }
+
         $rules = array(
             'username'    =>'required'
         );


### PR DESCRIPTION
JOINDIN-139

I believe this fixes the issue described in JOINDIN-139. When I was in there and testing with the apitester though, it appears that in order for the username to properly be read, it must be passed in quoted. It also means that this API is SQL injection vulnerable. I don't know if the iPhone app is passing in quoted values or not but I didn't want to change the behavior (I put the 'u' in the last word but it underlined it, sorry :) ) without having a bit of discussion about it first. I don't want to break the iPhone app by making it escape any provided quotes.  

Please advise on that.
