### PR TITLE
Reverted privacy level of $CI in BaseWsRequest - See Jira 236

### DIFF
--- a/src/system/application/libraries/wsactions/BaseWsRequest.php
+++ b/src/system/application/libraries/wsactions/BaseWsRequest.php
@@ -23,7 +23,7 @@ if (!defined('BASEPATH')) {
 */
 class BaseWsRequest
 {
-    protected $CI = null;
+    private $CI = null;
     
     /**
      * Instantiates the base object and attached the CodeIgniter instance


### PR DESCRIPTION
Reverted privacy level of $CI member variable / field in BaseWsRequest from
protected back to private as the change was causing exceptions and had broken
the mobile apps!

See Jira 236 (https://joindin.jira.com/browse/JOINDIN-236)

File changed:
   src/system/application/libraries/wsactions/BaseWsRequest.php
