### PR TITLE
correcting an issue where we would try to recursively XMLize a boolean(t...

### DIFF
--- a/src/system/application/views/api/out_xml.php
+++ b/src/system/application/views/api/out_xml.php
@@ -4,7 +4,7 @@ function addArrayToXML($xml, $data) {
         if (is_numeric($key)) {
             $key = "item";
         }
-        if (is_string($item) or empty($item)) {
+        if (is_string($item) || empty($item) || is_bool($item)) {
             // we might have an empty array, this is expected
             if (is_array($item) AND count($item) == 0) {
                 $item = '';


### PR DESCRIPTION
...rue) value

Spotted when running event/getdetail as this includes the user_attending field and causes an HTML error to be output before the XML content
