### PR TITLE
Added category details to talks API.

### DIFF
--- a/src/api-v2/models/TalkMapper.php
+++ b/src/api-v2/models/TalkMapper.php
@@ -55,6 +55,7 @@ class TalkMapper extends ApiMapper {
                 // add speakers
                 $list[$key]['speakers'] = $this->getSpeakers($row['ID']);
                 $list[$key]['tracks'] = $this->getTracks($row['ID']);
+                $list[$key]['category'] = $this->getCategory($row['ID']);
                 $list[$key]['uri'] = $base . '/' . $version . '/talks/' . $row['ID'];
                 $list[$key]['verbose_uri'] = $base . '/' . $version . '/talks/' . $row['ID'] . '?verbose=yes';
                 $list[$key]['website_uri'] = 'http://joind.in/talk/view/' . $row['ID'];
@@ -145,6 +146,23 @@ class TalkMapper extends ApiMapper {
            foreach($tracks as $track) {
                $retval[] = $track;
            }
+        }
+        return $retval;
+    }
+
+    protected function getCategory($talk_id) {
+        $host = $this->_request->host;
+        $category_sql = 'select categories.* '
+            . 'from categories '
+            . 'inner join talk_cat tc on categories.ID = tc.cat_id '
+            . 'where tc.talk_id = :talk_id';
+        $category_stmt = $this->_db->prepare($category_sql);
+        $category_stmt->execute(array("talk_id" => $talk_id));
+        $category = $category_stmt->fetch(PDO::FETCH_ASSOC);
+        $retval = array();
+        if(is_array($category)) {
+           $retval['category_title'] = $category['cat_title'];
+           $retval['category_description'] = $category['cat_desc'];
         }
         return $retval;
     }

--- a/src/tests/api_tests/newapi_spec.js
+++ b/src/tests/api_tests/newapi_spec.js
@@ -294,5 +294,7 @@ function checkTalk(talk) {
   expect(typeof talk.comments_enabled).toBe('number');
   expect(talk.comment_count).toBeDefined();
   expect(typeof talk.comment_count).toBe('number');
+  expect(talk.category).toBeDefined();
+  expect(typeof talk.category).toBe('object');
 }
 


### PR DESCRIPTION
This adds a talk's category details (keynote, talk, etc) into the API v2 talks call output, in the format:

```
talks:
    0:
        talk_title: Maintaining optimal operations through Linux
        ....
        category:
            category_title: Social
            category_description: Social event
```
