### PR TITLE
Ignore style sniffs on CI code - JOINDIN-230

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -50,6 +50,7 @@
      <phpcodesniffer standard="doc/codesniffer/JoindIn/" verbosity="1">
    <fileset dir="${source}">
        <exclude name="views/**"/>
+       <exclude name="libraries/Template.php" />
    </fileset>
    <formatter type="checkstyle" outfile="${basedir}/build/logs/checkstyle.xml" />
   </phpcodesniffer>


### PR DESCRIPTION
Tells codesniff to ignore the Template.php file in our code because it's a code igniter file.
