### PR TITLE
JOINDIN-260 phing task for making codesniff easy for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,28 @@ Then run the tests by going to `/src/tests/api_tests` and running:
 ### Unit Tests
 
 There are some tests set up, which use PHPUnit; these can be found in the
-src/tests directory.  There is a phing task configured to run them - from the
-root directory simply run "phing phpunit" to run the tests.
+src/tests directory and the src/api-v2/tests directory.  There is a phing task
+configured to run them - from the root directory simply run "phing phpunit" to run
+the tests. Unfortunately, there will be no output about whether the tests passed
+or failed from the phing target. A better way to test when you are developing is
+to run the tests from within the respective tests directory by just typing
+phpunit. The phpunit.xml in each directory will configure the bootstrap as well
+as any files that should not be included.
+
+The phpunit.xml file in the src/tests directory will run all of the PHPUnit tests.
+The phpunit.xml file in src/api-v2/tests will run only the API v2 unit tests.
+
+### CODE STYLE
+
+Please do your best to ensure that any code you contributed adheres to the
+Joind.in coding style. This is roughly equivalent to the PEAR coding standard with
+a couple of rules added or taken out. You can run php codesniffer using phing on an
+individual file like so:
+
+phing phpcs-human -Dfilename.php
+
+This will run codesniffer on any file within the regular source for Joind.in or the
+API-v2 source. Wildcards work as does specifying part of the path in case the
+filename alone results in sniffing more files than you wanted.
+
 

--- a/build.xml
+++ b/build.xml
@@ -2,6 +2,7 @@
 
 <project name="joindin" default="build" basedir=".">
  <property name="source" value="src/system/application/"/>
+ <property name="apiv2source" value="src/api-v2/" />
  <property name="basedir" value="."/>
 
  <target name="clean" description="Clean up and create artifact directories">
@@ -55,6 +56,24 @@
    <formatter type="checkstyle" outfile="${basedir}/build/logs/checkstyle.xml" />
   </phpcodesniffer>
  </target>
+
+
+<target name="phpcs-human" description="Check codes style with PHP_CodeSniffer">
+    <phpcodesniffer standard="doc/codesniffer/JoindIn/">
+        <fileset dir="${source}">
+            <patternset>
+                <include name="**/${filename}" />
+            </patternset>
+            <exclude name="views/**"></exclude>
+            <exclude name="libraries/Template.php" />
+        </fileset>
+        <fileset dir="${apiv2source}">
+            <patternset>
+                <include name="**/${filename}" />
+            </patternset>
+        </fileset>
+    </phpcodesniffer>
+</target>
 
  <target name="phpdoc" description="Generate API documentation using PHPDocumentor">
   <phpdoc2 destdir="${basedir}/build/api">


### PR DESCRIPTION
This PR allows for an easy way for contributors who have phpcs and phing installed to codesniff the files in their contribution before making a PR.

phing phpcs-human -Dfilename=Request.php

This will codesniff all files that end with Request.php in the joind.in source or api-v2 source directories. In the example above, it would find 

src/api-v2/inc/Request.php 
and
src/system/application/libraries/wsactions/BaseWsRequest.php

By specifying a more specific file designation, like inc/Request.php, the developer can ensure that codesniff is only run on the one desired file.

The output is color coded and grouped for errors and warnings.

The remaining phing tasks were not affected and since this is a standalone target, not mentioned in any of the build targets, it will not affect the build.

Additionally, some edits to the README.md file were make to update about how to run phpcs as well as how to run phpunit since the previous instructions would not result in expected behavior.

![Screenshot_2_11_13_12_35_AM](https://f.cloud.github.com/assets/775393/144454/913e21e4-741d-11e2-9c2c-4cefaf2f95f4.png)
