### PR TITLE
making a new talk comment give a 201 Created response plus Location header

### DIFF
--- a/src/api-v2/controllers/TalksController.php
+++ b/src/api-v2/controllers/TalksController.php
@@ -72,7 +72,7 @@ class TalksController extends ApiController {
                 $data['rating'] = $rating;
 
                 $comment_mapper->save($data);
-                header("Location: " . $request->base . $request->path_info);
+                header("Location: " . $request->base . $request->path_info, true, 201);
                 exit;
             }
         } else {


### PR DESCRIPTION
We were sending a 302 which isn't right!  Not aware of anyone or anything currently posting comments via the API so I think this is a safe change to make - although we still do not have tests for writes in the API v2
