### PR TITLE
Fix JOINDIN-271 - Show old speaker claims in the pending claims page

### DIFF
--- a/doc/db/patch38.sql
+++ b/doc/db/patch38.sql
@@ -1,0 +1,15 @@
+-- Make sure claims sent before the addition of the table pending_talk_claims are working with the new system
+-- https://joindin.jira.com/browse/JOINDIN-271
+
+Insert Into pending_talk_claims (talk_id, submitted_by, speaker_id, date_added, claim_id)
+Select talk_id, null, speaker_id, null, id
+From talk_speaker 
+Where Status = 'pending';
+
+
+Update talk_speaker 
+Set speaker_id = null,
+status = null
+Where Status = 'pending';
+
+INSERT INTO patch_history SET patch_number = 38;


### PR DESCRIPTION
Older claims don't show because the way claims are saved in the db changed. 
https://joindin.jira.com/browse/JOINDIN-271
