### PR TITLE
Slides link on Talk view to open in new window/ tab

### DIFF
--- a/src/system/application/views/talk/modules/_talk_detail.php
+++ b/src/system/application/views/talk/modules/_talk_detail.php
@@ -59,7 +59,7 @@
     
     <?php if (!empty($detail->slides_link)): ?>
     <p class="quicklink">
-        Slides: <strong><a href="<?php echo $detail->slides_link; ?>"><?php echo $detail->talk_title; ?></a></strong>
+        Slides: <strong><a href="<?php echo $detail->slides_link; ?>" target="_blank"><?php echo $detail->talk_title; ?></a></strong>
     </p>
     <?php endif; ?>
 


### PR DESCRIPTION
As discussed with @lornajane on IRC - this PR adds a target attribute to the slides tag to make it open in a new window/ tab when clicked.
