### PR TITLE
JOINDIN-272 - Event comments - timezone offset

### DIFF
--- a/src/system/application/views/event/modules/_event_tab_comments.php
+++ b/src/system/application/views/event/modules/_event_tab_comments.php
@@ -21,11 +21,16 @@ if (!empty($msg)):
             $uname = "<span class=\"anonymous\">Anonymous</span>";
         }
         $type	= ($event_detail->event_start>time()) ? 'Suggestion' : 'Feedback';
+
+	$this->load->helper('date');
+
+	$event_timezone = ($event->event_tz_cont && $event->event_tz_place) ? $event->event_tz_cont . '/' . $event->event_tz_place : 'Europe/London';
+	$comment_made = gmt_to_local_2($comment->date_made, $event_timezone);
     ?>
     <div id="comment-<?php echo $comment->ID ?>" class="row row-event-comment">
         <div class="text">
             <p class="info">
-                <strong><?php echo date('d.M.Y \a\t H:i', $comment->date_made); ?></strong> by <strong><?php echo $uname; ?></strong>
+                <strong><?php echo date('d.M.Y \a\t H:i', $comment_made); ?></strong> by <strong><?php echo $uname; ?></strong>
                 <?php echo !empty($comment->source)?"via ".escape($comment->source) : "" ?>
                 (<?php echo escape($type); ?>)
             </p>

--- a/src/system/helpers/date_helper.php
+++ b/src/system/helpers/date_helper.php
@@ -343,6 +343,49 @@ if ( ! function_exists('gmt_to_local'))
 		return $time;
 	}
 }
+
+// ------------------------------------------------------------------------
+
+/**
+ * Converts GMT time to a localized value
+ *
+ * Takes a Unix timestamp (in GMT) as input, and returns
+ * at the local value based on the timezone and DST setting
+ * submitted
+ *
+ * @access	public
+ * @param	integer Unix timestamp
+ * @param	string	timezone
+ * @param	bool	whether DST is active
+ * @return	integer
+ */	
+if ( ! function_exists('gmt_to_local_2'))
+{
+	function gmt_to_local_2($time = '', $timezone = 'Europe/London', $dst = FALSE)
+	{			
+		if ($time == '')
+		{
+			return now();
+		}
+	
+		$timezone_orig = new DateTimeZone('Europe/London');
+		$timezone_offset = new DateTimeZone($timezone);
+
+		$timenow_london = new DateTime('now', $timezone_orig);
+		$timenow_offset = new DateTime('now', $timezone_offset);
+
+		$offset = $timezone_offset->getOffset($timenow_london);
+
+		$time += $offset;
+
+		if ($dst == TRUE)
+		{
+			$time += 3600;
+		}
+	
+		return $time;
+	}
+}
 	
 // ------------------------------------------------------------------------
 


### PR DESCRIPTION
Hi,

This is fixes JOINDIN-272 issue. I've created a new helper ( **Which really needs a new name, but unsure what to go for** ).

I've applied the fix to the **_event_tab_comments.php** template, and it seems to work - tested on America/Montreal. **Defaults to Europe/London** if no Timezone is given in the Event.

Thanks,
Alan
