### PR TITLE
Escaping some outputs to prevent or cause XSS to be more difficult.

### DIFF
--- a/src/system/application/views/event/add.php
+++ b/src/system/application/views/event/add.php
@@ -10,9 +10,10 @@ $showFields = array();
 if (isset($this->edit_id) && $this->edit_id) {
     echo form_open_multipart('event/edit/'.$this->edit_id);
     $sub	='Save Edits';
-    $title	='Edit Event: <a style="text-decoration:none" href="/event/view/'.$detail[0]->ID.'">'.$detail[0]->event_name.'</a>';
+    $title	='Edit Event: <a style="text-decoration:none" href="/event/view/'
+        .$detail[0]->ID.'">'.escape($detail[0]->event_name).'</a>';
     $curr_img = $detail[0]->event_icon;
-    menu_pagetitle('Edit Event: '.$detail[0]->event_name);
+    menu_pagetitle('Edit Event: '. escape($detail[0]->event_name));
 } else { 
     echo form_open_multipart('event/add'); 
     $sub	= 'Add Event';

--- a/src/system/application/views/event/claim.php
+++ b/src/system/application/views/event/claim.php
@@ -43,18 +43,20 @@ claim the session. You can then accept/deny based on any match between them.
                 'id'	=> 'talkid-'.$claim->talk_id.'-'.$claim->ID.'-deny'
             )); ?></td>
             <td>
-                <a href="/talk/view/<?php echo $claim->talk_id; ?>"><?php echo $claim->talk_title; ?></a>
+                <a href="/talk/view/<?php echo $claim->talk_id; ?>"><?php echo
+                    escape($claim->talk_title); ?></a>
             </td>
             <td>
                 <?php
                 $speakers = array();
                 foreach ($claim->claim_detail as $detail) {
-                    $speakers[] = $detail->speaker_name;
+                    $speakers[] = escape($detail->speaker_name);
                 }
                 echo implode(', ', $speakers);
                 ?>
             </td>
-            <td><?php echo '<a href="/user/view/'.$claim->speaker_id.'">'.$claim->full_name.'</a>'; ?></td>
+            <td><?php echo '<a href="/user/view/'.$claim->speaker_id.'">'
+                    .escape($claim->full_name).'</a>'; ?></td>
         </tr>
         <?php endforeach; ?>
     </table>

--- a/src/system/application/views/event/claims.php
+++ b/src/system/application/views/event/claims.php
@@ -14,9 +14,11 @@
             <td align="center"><?php echo form_radio('claim['.$claim->ua_id.']','approve'); ?></td>
             <td align="center"><?php echo form_radio('claim['.$claim->ua_id.']','deny'); ?></td>
             <td>
-                <?php echo '<a href="/event/view/'.$claim->eid.'">'.$claim->event_name.'</a>'; ?><br/>
+                <?php echo '<a href="/event/view/'.$claim->eid.'">'
+                    .escape($claim->event_name).'</a>'; ?><br/>
             </td>
-            <td><?php echo '<a href="/user/view/'.$claim->uid.'">'.$claim->claiming_name.'</a>'; ?></td>
+            <td><?php echo '<a href="/user/view/'.$claim->uid.'">'
+                    .escape($claim->claiming_name).'</a>'; ?></td>
         </tr>
         <?php endforeach; ?>
     </table>

--- a/src/system/application/views/event/modules/_event_tab_slides.php
+++ b/src/system/application/views/event/modules/_event_tab_slides.php
@@ -3,9 +3,10 @@
     <?php foreach ($slides_list as $sk=>$sv): ?>
         <tr class="<?php echo ($ct%2==0) ? 'row1' : 'row2'; ?>">
         <td>
-        <a href="/talk/view/<?php echo $sk; ?>"><?php echo $sv['title']; ?></a>
+        <a href="/talk/view/<?php echo $sk; ?>"><?php echo escape($sv['title']);
+            ?></a>
         </td>
-        <td><?php echo $sv['speaker']; ?>
+        <td><?php echo escape($sv['speaker']); ?>
         <td>
         <a href="<?php echo $sv['link']; ?>">Slides</a>
         </td>

--- a/src/system/application/views/event/modules/_event_tab_talks.php
+++ b/src/system/application/views/event/modules/_event_tab_talks.php
@@ -60,9 +60,10 @@
                 foreach ($talk->speaker as $speaker) {
                     if (isset($claimed[$talk->ID][$speaker->speaker_id])) {
                         $claim_data = $claimed[$talk->ID][$speaker->speaker_id];
-                        $speaker_list[]='<a href="/user/view/'.$claim_data->speaker_id.'">'.$claim_data->full_name.'</a>';
+                        $speaker_list[]='<a href="/user/view/'.$claim_data->speaker_id.'">'.
+                            escape($claim_data->full_name).'</a>';
                     } else {
-                        $speaker_list[]=$speaker->speaker_name; 
+                        $speaker_list[]=escape($speaker->speaker_name);
                     }
                     
                 }

--- a/src/system/application/views/talk/_talk-row.php
+++ b/src/system/application/views/talk/_talk-row.php
@@ -23,9 +23,10 @@
                     if (isset($override) && array_key_exists($speaker->speaker_id, $override)) {
                         $speaker->speaker_name = $override[$speaker->speaker_id];
                     }
-                    $speaker_list[]='<a href="/user/view/'.$speaker->speaker_id.'">'.$speaker->speaker_name.'</a>';
+                    $speaker_list[]='<a href="/user/view/'.$speaker->speaker_id
+                        .'">'.escape($speaker->speaker_name).'</a>';
                 } else {
-                    $speaker_list[]=$speaker->speaker_name;
+                    $speaker_list[]=escape($speaker->speaker_name);
                 }
             }
         }

--- a/src/system/application/views/talk/add.php
+++ b/src/system/application/views/talk/add.php
@@ -16,7 +16,7 @@ if (!empty($this->validation->error_string)) {
 if (isset($this->edit_id)) {
     $actionUrl = 'talk/edit/'.$this->edit_id;
     $sub	= 'Save Edits';
-    $title	= 'Edit Session: '.$detail[0]->talk_title;
+    $title	= 'Edit Session: '.escape($detail[0]->talk_title);
     menu_pagetitle('Edit Session: '.$detail[0]->talk_title);
 } else { 
     $actionUrl =  'talk/add/event/'.$ev->ID;

--- a/src/system/application/views/talk/modules/_talk_buttons.php
+++ b/src/system/application/views/talk/modules/_talk_buttons.php
@@ -5,7 +5,7 @@
     $speaker_list = array();
     foreach ($speakers as $speaker) {
         if (empty($speaker->speaker_id)) {
-            $speaker_list[$speaker->ID]=$speaker->speaker_name;
+            $speaker_list[$speaker->ID]=escape($speaker->speaker_name);
         }
     }
     echo form_dropdown('claim_name_select', $speaker_list, null,'id="claim_name_select"');

--- a/src/system/application/views/talk/modules/_talk_detail.php
+++ b/src/system/application/views/talk/modules/_talk_detail.php
@@ -10,13 +10,14 @@
             <?php 
             if (!empty($speaker->speaker_id) && $speaker->status!='pending') {
                 if (empty($speaker->full_name)) { $speaker->full_name = 'N/A'; }
-                $speaker_link = '<a href="/user/view/'.$speaker->speaker_id.'">'.$speaker->full_name.'</a> ';
+                $speaker_link = '<a href="/user/view/'.$speaker->speaker_id.'">'
+                    .escape($speaker->full_name).'</a> ';
                 if ($admin) {
                     $speaker_link .= '<a class="btn-small" href="/talk/unlink/'.$speaker->talk_id.'/'.$speaker->speaker_id.'">< unlink</a>';
                 }
                 $speaker_names[] = $speaker_link;
             } else {
-                $speaker_names[] = $speaker->speaker_name;
+                $speaker_names[] = escape($speaker->speaker_name);
             }
             ?>
             <?php endforeach; echo implode(', ', $speaker_names); ?>
@@ -59,7 +60,9 @@
     
     <?php if (!empty($detail->slides_link)): ?>
     <p class="quicklink">
-        Slides: <strong><a href="<?php echo $detail->slides_link; ?>" target="_blank"><?php echo $detail->talk_title; ?></a></strong>
+        Slides: <strong><a href="<?php echo $detail->slides_link; ?>"
+                           target="_blank"><?php echo escape($detail->talk_title);
+                ?></a></strong>
     </p>
     <?php endif; ?>
 

--- a/src/system/application/views/theme/index.php
+++ b/src/system/application/views/theme/index.php
@@ -16,8 +16,9 @@
 $bg=($theme->active==1) ? '#E9E9E9' : '#FFFFFF';
 ?>
 <tr style="background-color:<?php echo $bg; ?>">
-    <td><?php echo $theme->theme_name; ?></td>
-    <td><a href="/event/view/<?php echo $theme->event_id; ?>"><?php echo $theme->event_name; ?></a></td>
+    <td><?php echo escape($theme->theme_name); ?></td>
+    <td><a href="/event/view/<?php echo $theme->event_id; ?>"><?php echo
+            escape($theme->event_name); ?></a></td>
     <td>
         <?php echo ($theme->active==1) ? 'active' : 'inactive'; ?>
     </td>

--- a/src/system/application/views/user/view.php
+++ b/src/system/application/views/user/view.php
@@ -268,7 +268,8 @@ foreach ($talks as $k=>$v) {
                         </td>
                         <td style="padding:3px">[<a href="javascript:" onClick="unlinkSpeaker(%s, %s, \'%s\');return false;" title="Unlink this speaker">X</a>]</td>
                     </tr>
-                ', $row_id, $url, $title, $event_url, $event_name, $event_date, $v->ID, $v->speaker_id, $row_id);
+                ', $row_id, $url, $title, $event_url, escape($event_name),
+                $event_date, $v->ID, $v->speaker_id, $row_id);
             }
 
             ?>


### PR DESCRIPTION
Someone opened a ticket about talk titles not being escaped which was found during Tek. That one spot got fixed but I guessed that there were some other places that would be vulnerable to XSS. It turns out that it was true.

This pull request escapes the output for several different fields that I found to be vulnerable to XSS. Speaker names, talk titles, event names, theme names and a few others all have areas where they were output unescaped. The ones included in the patch were all verified by testing and debugging but it is not guaranteed to be a comprehensive fix.
