### PR TITLE
Move from using redirect() to raw Location: header.

### DIFF
--- a/src/system/application/controllers/user.php
+++ b/src/system/application/controllers/user.php
@@ -883,7 +883,11 @@ class User extends AuthAbstract
                     if (!empty($state)) {
                         $url .= "&state=" . $state;
                     }
-                    redirect($url);
+
+                    // Don't use the CodeIgniter redirect() call here
+                    // as it always prepends the site URL
+                    // which is no good for custom URL schemes
+                    header('Location: ' . $url);
                     exit; // we shouldn't be here
                 }
             } else {


### PR DESCRIPTION
This allows custom URL schemes if required, for OAuth callbacks.  The built-in CodeIgniter `redirect()` function always adds the configured site URL, which breaks supplying URLs such as `joindin://foo` . This can be used client-side in mobile apps to catch the callback and do something accordingly that doesn't involve a web browser.
