### PR TITLE
OAuth allow - explicitly set URL to return to.

### DIFF
--- a/src/system/application/controllers/user.php
+++ b/src/system/application/controllers/user.php
@@ -822,6 +822,9 @@ class User extends AuthAbstract
     function oauth_allow()
     {
         if (!$this->user_model->isAuth()) {
+            // Explicitly set the URL to return to
+            // Relying on the referrer being present can cause issues when it isn't present
+            $this->session->set_flashdata("url_after_login", $this->input->server("REQUEST_URI"));
             redirect('user/login', 'refresh');
         }
 


### PR DESCRIPTION
This solves the IE issue whereby IE doesn't always send the referer header.  Testing with IE9 and IE10, it appears that IE doesn't always send the correct HTTP Referer header, and since the user login logic checks for the referer to send the user back to the right place post-login, we should explicitly set the OAuth authorisation URL to go back to.
