### PR TITLE
JOINDIN-242 : Fixed double quotes on search tag

### DIFF
--- a/src/system/application/models/event_model.php
+++ b/src/system/application/models/event_model.php
@@ -513,7 +513,7 @@ SQL
             FROM events, tags_events, tags
             WHERE active = 1 AND (pending = 0 OR pending IS NULL) AND
             tags_events.event_id = events.ID AND tags_events.tag_id = tags.ID AND
-            tags.tag_value = "'.$this->db->escape($tagData).'"
+            tags.tag_value = '.$this->db->escape($tagData).'
             ORDER BY events.event_start ASC';
 
         $query  = $this->db->query($sql);


### PR DESCRIPTION
$this->db->escape adds quotes, so the second set of quotes was redundant.
