### PR TITLE
Added title when listing talks by name in user page view

### DIFF
--- a/src/system/application/views/user/view.php
+++ b/src/system/application/views/user/view.php
@@ -68,7 +68,7 @@ switch ($sort_type) {
             $talks_by_name[trim($talk->talk_title)][]=$talk;
         }
         ksort($talks_by_name);
-        break;
+        $title = 'Talks (By Name)'; break;
     default:
         $title = 'Talks'; break;
 }


### PR DESCRIPTION
In User view page, "Talks" section title disappears when you click 'By Name', so just added title when listing talks by name 
