### PR TITLE
Avoid mixed content warning when querying openstreetmap

### DIFF
--- a/src/system/application/views/event/submit.php
+++ b/src/system/application/views/event/submit.php
@@ -33,7 +33,7 @@ $(document).ready(function(){
     // Setup the click handler for the search button.
     $('#addr_search_button').click(function(){
         console.log('Searching for: ', $('#addr').val());
-        $.getJSON('http://nominatim.openstreetmap.org/search?format=json&limit=5&q=' + $('#addr').val(), function(data) {
+        $.getJSON('https://nominatim.openstreetmap.org/search?format=json&limit=5&q=' + $('#addr').val(), function(data) {
             var items = [];
 
             var $addrSelector = $('#addr_selection');


### PR DESCRIPTION
This makes the location selector work in firefox.

For some reason Chrome allows this request - I don't think it should really.

As this is such a simple fix, I just used the "edit" button in github, let me know if there's other stuff I need to fill in.
