### PR TITLE
JRA-319 #resolve #comment Set lat and long to 0.0, 0.0 set zoom to 0 als...

### DIFF
--- a/src/system/application/views/event/submit.php
+++ b/src/system/application/views/event/submit.php
@@ -223,7 +223,7 @@ $(document).ready(function(){
                     <ul id="addr_selection"></ul>
                 </td>
                 <td align="right">
-                    <div id="map" class="osmMap" data-lat="53.8000" data-lon="-1.5833" data-zoom="5"></div>
+                    <div id="map" class="osmMap" data-lat="0.0" data-lon="0.0" data-zoom="1"></div>
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
I have a fix for JOINDIN-319. The default lat/long were positioned by default over Leeds. I changed it to a less arbitrary 0.0,0.0. I also changed the zoom leve, as 0.0,0.0 ,at the previous zoom level looked a bit odd, much sea to be seen. 
