### PR TITLE
Switching around comment form and existing comments to prevent biasing

### DIFF
--- a/src/system/application/views/talk/detail.php
+++ b/src/system/application/views/talk/detail.php
@@ -41,8 +41,8 @@ $this->load->view('talk/modules/_talk_buttons', $data);
 
 <?php 
 $data=array();
+$this->load->view('talk/modules/_talk_comment_form', $data);
 $this->load->view('talk/modules/_talk_comments', $data);
-$this->load->view('talk/modules/_talk_comment_form', $data); 
 ?>
 <input type="hidden" name="talk_id" id="talk_id" value="<?php echo $detail->ID ?>" />
 <input type="hidden" name="user_id" id="user_id" value="<?php echo $user_id ?>" />


### PR DESCRIPTION
This is to better avoid rating biasing.
If you havent rated a talk yet, then having
to scroll past other peoples views will slight
your review.
