### PR TITLE
Fix broken approval link on event page.

### DIFF
--- a/src/system/application/views/event/modules/_event_buttons.php
+++ b/src/system/application/views/event/modules/_event_buttons.php
@@ -1,7 +1,7 @@
 <p class="admin">
 <?php if ($admin): ?>
     <?php if (isset($event_detail->pending) && $event_detail->pending==1) : ?>
-        <a class="btn-small" href="/event/approve/'<?php echo $event_detail->ID; ?>">Approve Event</a>';
+        <a class="btn-small" href="/event/approve/<?php echo $event_detail->ID; ?>">Approve Event</a>
     <?php endif; ?>
 <?php endif; ?>
 </p>


### PR DESCRIPTION
Fixed issue: https://joindin.jira.com/browse/JOINDIN-452

Test:
1. Submit an event
2. Navigate to the event page.
3. Verify that you can click the "Approve Event" link.
