### PR TITLE
Using https to avoid the non-secure warning 

### DIFF
--- a/src/inc/js/jq.joindIn.js
+++ b/src/inc/js/jq.joindIn.js
@@ -70,7 +70,7 @@
                     
                     // Initialise the map
                     var map = new L.Map(mapDiv.attr('id'), {zoomControl: true});
-                    var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                         osmAttribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
                         osm = new L.TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttribution});
                     


### PR DESCRIPTION
Hi guys!

As an example: https://joind.in/event/view/2166 - it gives you the "non-secure" warning - i.e. the page includes some non-https assets. We could probably also use the `//` protocol so that it matches the protocol used by the visitor on the site.

I _did_ verify that the https `tile.openstreemap.org` URLs work identically to the `http` version. This seems like a simple enough change, but I did _not_ actually get the code working locally to verify.

Thanks!
