### PR TITLE
Fixes #JOINDIN-502

### DIFF
--- a/src/inc/js/event_osm_map.js
+++ b/src/inc/js/event_osm_map.js
@@ -41,7 +41,7 @@ function chooseAddr(lat, lng) {
 function addr_search() {
 	var inp = document.getElementById("addr");
 
-    $.getJSON('http://nominatim.openstreetmap.org/search?format=json&limit=5&q=' + inp.value, function(data) {
+    $.getJSON('//nominatim.openstreetmap.org/search?format=json&limit=5&q=' + inp.value, function(data) {
         var items = [];
 
         $.each(data, function(key, val) {

--- a/src/system/application/views/event/submit.php
+++ b/src/system/application/views/event/submit.php
@@ -32,7 +32,7 @@ $(document).ready(function(){
 
     // Setup the click handler for the search button.
     $('#addr_search_button').click(function(){
-        $.getJSON('http://nominatim.openstreetmap.org/search?format=json&limit=5&q=' + $('#addr').val(), function(data) {
+        $.getJSON('//nominatim.openstreetmap.org/search?format=json&limit=5&q=' + $('#addr').val(), function(data) {
             var items = [];
 
             var $addrSelector = $('#addr_selection');


### PR DESCRIPTION
Just removes the 'http:'-part so that browsers call the nominatim-server via the appropriate scheme.

As nominatim is also available via https that seems to be no problem. I'm not sure though how different browsers do handle this. Testet in Firefox and Safari to work.
