### PR TITLE
Use CURL_SSLVERSION_TLSv1 for outbound ssl connections

### DIFF
--- a/src/system/application/libraries/twitter_oauth.php
+++ b/src/system/application/libraries/twitter_oauth.php
@@ -192,7 +192,7 @@ class twitter_oauth
     {
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-        curl_setopt($ch, CURLOPT_SSLVERSION, 3);
+        curl_setopt($ch, CURLOPT_SSLVERSION, 1);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
This corrects the issues with Twitter disabling SSLv3 in their API due to POODLE.
