### PR TITLE
Add talk comment validation rules

### DIFF
--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -681,9 +681,12 @@ class Talk extends Controller
 
             if ($acceptable_comment && $sp_ret == true) {
 
+                // if the user has already rated, then the rating for this comment is zero
+                $rating = $already_rated ? 0 : $this->input->post('rating');
+
                 $arr = array(
                     'talk_id'   => $id,
-                    'rating'    => $this->input->post('rating'),
+                    'rating'    => $rating,
                     'comment'   => $this->input->post('comment'),
                     'date_made' => time(), 'private' => $priv,
                     'active'    => 1,


### PR DESCRIPTION
Prevent duplicate comments and ratings outside of 0-5.
Also ensure that a user's second comment to a thread is always rated as zero.

JOINDIN-515 #close fixed.
