### PR TITLE
Only enable the spamcheck service if $params['api_key'] has something in it

### DIFF
--- a/src/system/application/libraries/Spamcheckservice.php
+++ b/src/system/application/libraries/Spamcheckservice.php
@@ -10,7 +10,7 @@ class Spamcheckservice
 
     public function __construct($params = null)
     {
-        if (isset($params['api_key'])) {
+        if (isset($params['api_key']) && $params['api_key']) {
             $this->akismetUrl = 'http://' . $params['api_key'] . '.rest.akismet.com';
         }
     }


### PR DESCRIPTION
The config.php.dist file sets $config['akismet_key']  = '', which passes the isset() test, but then isCommentAcceptable() will always return false which makes it impossible to test anonymous comments unless you have a valid Akismet key,
