### PR TITLE
Comment rating fix

### DIFF
--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -1139,7 +1139,7 @@ class Talk extends Controller
         
         $this->validation->set_message(
             'rating_check',
-            'Rating is out of bounds.'
+            'Please choose a rating.'
         );
 
         return false;

--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -619,7 +619,7 @@ class Talk extends Controller
         //      1. duplicate_comment_check to ensure exact comment isn't posted twice
         $rating_rule = 'callback_rating_check';
         $rating_rule .= (in_array($currentUserId, $claim_user_ids)
-            || ($already_rated)) ? '' : 'required';
+            || ($already_rated)) ? '' : '|required';
 
         $rules = array(
             'rating' => $rating_rule,

--- a/src/system/application/controllers/talk.php
+++ b/src/system/application/controllers/talk.php
@@ -599,7 +599,8 @@ class Talk extends Controller
             foreach ($this->talks_model
                 ->getUserComments($this->user_model->getId()) as $comment) {
                 if ($comment->talk_id == $id) {
-                    $already_rated = true;
+                    $already_rated = $comment->ID;
+                    break;
                 }
             }
         }
@@ -681,12 +682,9 @@ class Talk extends Controller
 
             if ($acceptable_comment && $sp_ret == true) {
 
-                // if the user has already rated, then the rating for this comment is zero
-                $rating = $already_rated ? 0 : $this->input->post('rating');
-
                 $arr = array(
                     'talk_id'   => $id,
-                    'rating'    => $rating,
+                    'rating'    => $this->input->post('rating'),
                     'comment'   => $this->input->post('comment'),
                     'date_made' => time(), 'private' => $priv,
                     'active'    => 1,
@@ -704,6 +702,13 @@ class Talk extends Controller
                     if (isset($com_detail[0])
                         && ($com_detail[0]->user_id == $uid)
                     ) {
+
+                        // if the user has already rated and we're not editing that comment,
+                        // then the rating for this comment is zero
+                        if ($already_rated && $already_rated != $cid) {
+                            $arr['rating'] = 0;
+                        }
+
                         $commentEditTime = $com_detail[0]->date_made +
                             $this->config->item('comment_edit_time');
                         if (time() >= $commentEditTime) {


### PR DESCRIPTION
This PR fixes two main issues:

1. The rating validation check didn't work due to a missing pipe symbol.
2. Editing your first comment set the rating to zero.