### PR TITLE
Prevent registration via Twitter and Facebook

### DIFF
--- a/src/system/application/controllers/facebook.php
+++ b/src/system/application/controllers/facebook.php
@@ -111,26 +111,18 @@ class Facebook extends AuthAbstract
         }
 
         // return the first user with the given e-mail address
-        $user = current($this->user_model->getUserByEmail($facebook_user->email));
+        $user = $this->user_model->getUserByEmail($facebook_user->email);
 
         if (!$user) {
-            $username = $facebook_user->username;
-            if (!$username) {
-                // url_title acts as slugify method and filters unwanted characters
-                $username = url_title(strtolower($facebook_user->name));
-            }
-
-            $user = $this->_addUser(
-                $this->user_model->findAvailableUsername($username),
-                '', $facebook_user->email, $facebook_user->name, ''
-            );
-
-            // overwrite user and url to re-use the _login method
             $this->session->set_flashdata(
-                'url_after_login', site_url('user/manage')
+                'error_msg',
+                'You need to register with Joind.in and with the same email address'
+                .' as your Facebook account in order to sign in with Facebook'
             );
+            redirect(site_url('user/register'));
         }
 
+        $user = current($user);
         $this->_login($user);
     }
 

--- a/src/system/application/controllers/twitter.php
+++ b/src/system/application/controllers/twitter.php
@@ -96,29 +96,17 @@ class Twitter extends AuthAbstract
             );
         }
 
-        $user = current(
-            $this->user_model->getUserByTwitter($response['screen_name'])
-        );
-
+        $user = $this->user_model->getUserByTwitter($response['screen_name']);
         if ($user) {
+            $user = current($user);
             $this->_login($user);
         } else {
-            $user_info = $this->getTwitterUserdata($response['screen_name']);
-            $ret       = $this->_addUser(
-                $this->user_model->findAvailableUsername($response['screen_name']),
-                '', '', $user_info->name, $response['screen_name']
-            );
-
-            // now, since they're set up, log them in a push them to the account
-            // management page
-            $this->session->set_userdata((array)$ret);
             $this->session->set_flashdata(
-                'msg',
-                'To receive notifications; please enter your e-mail address.'
-                .'<br />Without a password you can only log in using your '
-                .'twitter account.'
+                'error_msg',
+                'You need to register with Joind.in and and set your Twitter'
+                .' Username in your profile in order to sign in with Twitter'
             );
-            redirect('user/manage');
+            redirect(site_url('user/register'));
         }
     }
 

--- a/src/system/application/views/user/register.php
+++ b/src/system/application/views/user/register.php
@@ -5,6 +5,12 @@ $msg=$this->session->flashdata('msg');
 if (!empty($msg)): 
 ?>
 <?php $this->load->view('msg_info', array('msg' => $msg)); ?>
+<?php endif;
+
+$error_msg=$this->session->flashdata('error_msg');
+if (!empty($error_msg)) :
+?>
+<?php $this->load->view('msg_error', array('msg' => $error_msg)); ?>
 <?php endif; ?>
 
 <div class="box">


### PR DESCRIPTION
Web1 is poor at automatically registering a user when they sign in using Twitter
or Facebook so this PR removes this ability and requires the user to register
with joind.in first.

The user is redirected to the registration page if necessary and the errors look like this:

![screen shot 2015-04-02 at 08 26 58](https://cloud.githubusercontent.com/assets/33135/6959940/d6e4aa4c-d915-11e4-80d8-a267fc652ddf.png)

![screen shot 2015-04-02 at 08 45 44](https://cloud.githubusercontent.com/assets/33135/6959907/87a15890-d915-11e4-9208-43b05252be4d.png)
