### PR TITLE
Remove pending events list

### DIFF
--- a/src/system/application/config/routes.php
+++ b/src/system/application/config/routes.php
@@ -60,7 +60,6 @@ $route['scaffolding_trigger'] = "";
 
 //$route['event/([^add|view|edit|delete])'] = 'event/cust/$1';
 $route['event/add']            = 'event/add';
-$route['event/pending']        = 'event/pending';
 $route['event/submit']         = 'event/submit';
 $route['event/approve/(:num)'] = 'event/approve/$1';
 $route['event/export/(:num)']  = 'event/export/$1';

--- a/src/system/application/config/routes.php
+++ b/src/system/application/config/routes.php
@@ -61,7 +61,6 @@ $route['scaffolding_trigger'] = "";
 //$route['event/([^add|view|edit|delete])'] = 'event/cust/$1';
 $route['event/add']            = 'event/add';
 $route['event/submit']         = 'event/submit';
-$route['event/approve/(:num)'] = 'event/approve/$1';
 $route['event/export/(:num)']  = 'event/export/$1';
 $route['event/edit/(:num)']    = 'event/edit/$1';
 $route['event/view/(:num)']    = 'event/view/$1';

--- a/src/system/application/controllers/event.php
+++ b/src/system/application/controllers/event.php
@@ -92,8 +92,6 @@ class Event extends Controller
      * @param string $type         Type of list to show, may be either hot,
      *                             upcoming, past. Anything else will result
      *                             in all events being shown.
-     * @param bool   $pending      Flag indicating whether to show pending
-     *                             or active events.
      * @param int    $per_page     Number of events per page
      * @param int    $current_page Current page to display
      *
@@ -101,7 +99,6 @@ class Event extends Controller
      */
     function _runList(
         $type,
-        $pending = false,
         $per_page = null,
         $current_page = null
     ) {
@@ -127,14 +124,6 @@ class Event extends Controller
             $events = $this->event_model
                 ->getPastEvents(null, $per_page, $current_page);
             break;
-        case 'pending':
-            $events = $this->event_model->getEventDetail(
-                null,
-                null,
-                null,
-                $pending
-            );
-            break;
         case 'hot':
             // hot is the default case
         default:
@@ -152,10 +141,6 @@ class Event extends Controller
             $e->user_attending = ($uid)
                 ? $this->user_attend_model->chkAttend($uid, $e->ID)
                 : false;
-
-            if ($type == 'pending') {
-                $e->admins = $this->event_model->getEventAdmins($e->ID);
-            }
         }
 
         $reqkey = buildReqKey();
@@ -187,56 +172,43 @@ class Event extends Controller
     }
 
     /**
-     * Displays a list of all pending or upcoming events.
+     * Displays a list of all hot events.
      *
-     * @param bool $pending Flag indicating whether to show pending or upcoming
-     *                      events
-     *
-     * @return bool
+     * @return void
      */
-    function index($pending = false)
+    function index()
     {
-        $type = ($pending) ? 'pending' : 'hot';
-        $this->_runList($type, $pending);
+        $this->_runList('hot');
     }
 
     /**
      * Displays an overview of all events.
      *
-     * @param bool $pending Flag indicating whether to show active or
-     *                      pending events.
-     *
      * @return void
      */
-    function all($pending = false)
+    function all()
     {
-        $this->_runList('index', $pending);
+        $this->_runList('index');
     }
 
     /**
      * Displays an overview of all hot events.
      *
-     * @param bool $pending Flag indicating whether to show active or
-     *                      pending events.
-     *
      * @return void
      */
-    function hot($pending = false)
+    function hot()
     {
-        $this->_runList('hot', $pending);
+        $this->_runList('hot');
     }
 
     /**
      * Displays an overview of all upcoming events.
      *
-     * @param bool $pending Flag indicating whether to show active or
-     *                      pending events.
-     *
      * @return void
      */
-    function upcoming($pending = false)
+    function upcoming()
     {
-        $this->_runList('upcoming', $pending);
+        $this->_runList('upcoming');
     }
 
     /**
@@ -248,27 +220,7 @@ class Event extends Controller
      */
     function past($current_page = null)
     {
-        // Don't display pending "past" events
-        $pending = false;
-        $this->_runList('past', $pending, 10, $current_page);
-    }
-
-    /**
-     * Displays an overview of all pending events.
-     *
-     * @return void
-     */
-    function pending()
-    {
-
-        if (!$this->user_model->isAuth()) {
-            redirect('/user/login', 'refresh');
-        }
-        if (!$this->user_model->isSiteAdmin()) {
-            redirect();
-        }
-
-        $this->index(true);
+        $this->_runList('past', 10, $current_page);
     }
 
     /**

--- a/src/system/application/controllers/event.php
+++ b/src/system/application/controllers/event.php
@@ -1527,43 +1527,6 @@ class Event extends Controller
     }
 
     /**
-     * Approve a pending event and send emails to the admins (if there are any).
-     *
-     * @param integer $id The id of the event
-     *
-     * @return void
-     */
-    function approve($id)
-    {
-        if (!$this->user_model->isSiteAdmin()) {
-            redirect();
-        }
-
-        $this->load->model('event_model');
-        $this->load->library('sendemail');
-        $this->event_model->approvePendingEvent($id);
-
-        // If we have admins for the event, send them an email to let them know
-        $admin_list = $this->event_model->getEventAdmins($id);
-        if ($admin_list && count($admin_list) > 0) {
-            $evt_detail = $this->event_model->getEventDetail($id);
-
-            // if the admin list is empty, use the contact info on the event
-            if (empty($admin_list)) {
-                $admin_list[] = array(
-                    'full_name' => $evt_detail->event_contact_name,
-                    'email'     => $evt_detail->event_contact_email
-                );
-            }
-
-            $this->sendemail->sendEventApproved($evt_detail[0], $admin_list);
-        }
-
-        // Finally, redirect back to the event!
-        redirect('event/view/' . $id);
-    }
-
-    /**
      * Allows a user to claim an event.
      *
      * Adds a pending row to the admin table for the site admins to go in

--- a/src/system/application/models/event_model.php
+++ b/src/system/application/models/event_model.php
@@ -148,12 +148,10 @@ class Event_model extends Model
      * @param integer $end_dt   If requesting events in a date range, this is the
      *                          upper date value (events earlier or equal to this
      *                          date will be returned)
-     * @param bool    $pending  Show only pending events, or only active
      *
      * @return stdClass[]
      */
-    function getEventDetail($id = null, $start_dt = null, $end_dt = null,
-        $pending = false
+    function getEventDetail($id = null, $start_dt = null, $end_dt = null
     ) {
         $this->load->helper("events");
 
@@ -190,17 +188,11 @@ SQL
         if ($this->user_model->isSiteAdmin() && isset($id)) {
             // just show it, no more filtering
         } else {
-            if ($pending) {
-                // pending events only
-                $db->where('(events.active', 0)
-                    ->where('events.pending', 1)
-                    ->ar_where[] = ')';
-            } else {
-                $db->where('(events.active', 1)
-                    ->where('(events.pending', null)
-                    ->or_where('events.pending', 0)
-                    ->ar_where[] = '))';
-            }
+            // active events only
+            $db->where('(events.active', 1)
+                ->where('(events.pending', null)
+                ->or_where('events.pending', 0)
+                ->ar_where[] = '))';
         }
 
         // determine the selection criteria, if $id is a number use that, otherwise

--- a/src/system/application/views/event/_event-row.php
+++ b/src/system/application/views/event/_event-row.php
@@ -48,20 +48,6 @@ $this->load->library('timezone');
             <?php endif; ?>
         <?php endif ?>
         </div>
-        <?php if (isset($view_type) && $view_type=='pending'): ?>
-        <p class="info"><b>Host<?php echo (count($event->admins) == 1) ? '' : 's' ?>:</b>
-                <?php
-                foreach ($event->admins as $key => $admin_user) {
-                    if ($key > 0) {
-                        echo ", ";
-                    }
-                    echo '<a href="/user/view/'.$admin_user->ID.'">'.$admin_user->full_name.'</a>';
-                }
-                ?>
-        </p>
-        <a style="color:#00C934;text-decoration:none;font-weight:bold;font-size:11px" href="/event/approve/<?php echo $event->ID ?>">APPROVE</a> -
-        <a style="color:#D6000E;text-decoration:none;font-weight:bold;font-size:11px" href="/event/delete/<?php echo $event->ID ?>">DENY</a>
-        <?php endif; ?>
     </div>
     <div class="clear"></div>
 </div>

--- a/src/system/application/views/event/detail.php
+++ b/src/system/application/views/event/detail.php
@@ -10,13 +10,6 @@ $data=array(
     'admins'		=> $admins
 );
 $this->load->view('event/modules/_event_detail', $data);
-
-// These are our buttons below the event detail
-$data=array(
-    'admin'			=> $admin,
-    'event_detail'	=> $event_detail
-);
-$this->load->view('event/modules/_event_buttons', $data);
 ?>
 
 <?php

--- a/src/system/application/views/event/modules/_event_buttons.php
+++ b/src/system/application/views/event/modules/_event_buttons.php
@@ -1,7 +1,0 @@
-<p class="admin">
-<?php if ($admin): ?>
-    <?php if (isset($event_detail->pending) && $event_detail->pending==1) : ?>
-        <a class="btn-small" href="/event/approve/<?php echo $event_detail->ID; ?>">Approve Event</a>
-    <?php endif; ?>
-<?php endif; ?>
-</p>

--- a/src/system/application/views/user/_nav_sidebar.php
+++ b/src/system/application/views/user/_nav_sidebar.php
@@ -4,15 +4,13 @@
  */
 $admin_nav_lnks='';
 if (user_is_admin()) {
-    $admin_nav_lnks=sprintf('
+    $admin_nav_lnks='
     <li><b>Admin Links</b>
     <ul>
     <li><a href="/user/admin">User Admin</a>
-    <li><a href="/event/pending">Pending Events</a> (%s)
     <li><a href="/talk/claim">Talk Claims</a>
     </ul>
-    ', count($pending_events)
-    );
+    ';
 }
 $nav=sprintf('
 <ul>

--- a/src/system/application/views/user/admin.php
+++ b/src/system/application/views/user/admin.php
@@ -10,7 +10,6 @@ $this->load->view('user/_nav_sidebar', array(
         <li><a href="/user/manage">Manage Account</a>
     <?php if (user_is_admin()): ?>
         <li class="active"><a href="/user/admin">User Admin</a>
-        <li><a href="/event/pending">Pending Events</a>
     <?php endif; ?>
     </ul>
     <div class="clear"></div>

--- a/src/system/application/views/user/main.php
+++ b/src/system/application/views/user/main.php
@@ -13,7 +13,6 @@ $this->load->view('user/_nav_sidebar', array(
         <li><a href="/user/manage">Manage Account</a></li>
     <?php if (user_is_admin()): ?>
         <li><a href="/user/admin">User Admin</a></li>
-        <li><a href="/event/pending">Pending Events</a></li>
     <?php endif; ?>
     </ul>
     <div class="clear"></div>

--- a/src/system/application/views/user/manage.php
+++ b/src/system/application/views/user/manage.php
@@ -10,7 +10,6 @@ $this->load->view('user/_nav_sidebar', array(
         <li class="active"><a href="/user/manage">Manage Account</a>
     <?php if (user_is_admin()): ?>
         <li><a href="/user/admin">User Admin</a>
-        <li><a href="/event/pending">Pending Events</a>
     <?php endif; ?>
     </ul>
     <div class="clear"></div>


### PR DESCRIPTION
While this PR isn't strictly necessary, now that we have the ability to deal with pending events on web2, we don't need this functionality in web1, especially as web2 has soft-delete when rejecting a pending event.

This PR removes the pending events list page and the approve action, but leaves viewing a single pending event alone as anyone could guess a pending event's id and navigate directly to the detail page.