### PR TITLE
Set pending events link in email to web2

### DIFF
--- a/src/system/application/controllers/event.php
+++ b/src/system/application/controllers/event.php
@@ -1468,8 +1468,7 @@ class Event extends Controller
                     $this->input->post('event_contact_name') . "\n\n";
                 $msg .= 'Event Contact Email: ' .
                     $this->input->post('event_contact_email') . "\n\n";
-                $msg .= 'View Pending Submissions: ' . $this->config->site_url()
-                    . 'event/pending' . "\n\n";
+                $msg .= "View Pending Submissions: https://m.joind.in/event/pending\n\n";
                 $msg .= 'Spam check: ' . ($is_spam == 'false')
                     ? 'not spam' : 'spam';
 


### PR DESCRIPTION
From now on, we want to use the new web2 pending events administration system, so point the link in the event submission notification email to the m.joind.in address.