### PR TITLE
Add a permissive robots.txt file

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow:


### PR DESCRIPTION
We're getting 404s in our logs because we're missing a robots.txt file.

The server has logic that sets disallow for everything on our test sites.