### PR TITLE
Fix event related tab on event page

### DIFF
--- a/src/system/application/models/event_model.php
+++ b/src/system/application/models/event_model.php
@@ -826,7 +826,17 @@ SQL
         );
 
         $q = $this->db->query($sql);
-        return $q->result();
+        $res = $q->result();
+
+        // get the speakers from the talk_speaker_model
+        $CI = &get_instance();
+        $CI->load->model('talk_speaker_model', 'tsm');
+        foreach ($res as $k => $talk) {
+            $res[$k]->speaker = $CI->tsm->getTalkSpeakers($talk->ID);
+        }
+
+
+        return $res;
     }
     
     /**

--- a/src/system/application/views/event/modules/_event_tab_evtrelated.php
+++ b/src/system/application/views/event/modules/_event_tab_evtrelated.php
@@ -11,7 +11,24 @@
         <td>
         <a href="/talk/view/<?php echo $iv->ID; ?>"><?php echo escape($iv->talk_title); ?></a>
         </td>
-        <td><?php echo $iv->speaker; ?></td>
+        <td>
+            <?php
+            if (isset($iv->speaker) && is_array($iv->speaker)) {
+                $speaker_list = array();
+                foreach ($iv->speaker as $speaker) {
+                    if (isset($claimed[$iv->ID][$speaker->speaker_id])) {
+                        $claim_data = $claimed[$iv->ID][$speaker->speaker_id];
+                        $speaker_list[]='<a href="/user/view/'.$claim_data->speaker_id.'">'.
+                            escape($claim_data->full_name).'</a>';
+                    } else {
+                        $speaker_list[]=escape($speaker->speaker_name);
+                    }
+                    
+                }
+                echo implode(', ', $speaker_list);
+            }
+            ?>
+        </td>
         <td>
         <a class="comment-count" href="/talk/view/<?php echo $iv->ID; ?>/#comments"><?php echo $iv->comment_count; ?></a>
         </td>


### PR DESCRIPTION
The speaker column is no longer available, so we need to get the data from the talk-speaker model instead.

This issue is hidden on live as display_errors is off, but is visible on the VM as the formatting of the event page is broken.